### PR TITLE
Phase 2.5: Frontend Pages for All Clinical Features

### DIFF
--- a/src/app/(dashboard)/appointments/[id]/page.tsx
+++ b/src/app/(dashboard)/appointments/[id]/page.tsx
@@ -1,0 +1,407 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { useParams, useRouter } from "next/navigation";
+import {
+  ArrowLeft,
+  Calendar,
+  Clock,
+  User,
+  Stethoscope,
+  FileText,
+  StickyNote,
+  CheckCircle2,
+  XCircle,
+  AlertTriangle,
+} from "lucide-react";
+import { useOrganization } from "@/lib/hooks/use-organization";
+import { orgApiFetch } from "@/lib/api";
+import Card, { CardBody, CardHeader } from "@/components/ui/Card";
+import Button from "@/components/ui/Button";
+import Badge from "@/components/ui/Badge";
+import Spinner from "@/components/ui/Spinner";
+import EmptyState from "@/components/ui/EmptyState";
+
+type BadgeVariant = "default" | "primary" | "accent" | "danger" | "warning" | "success";
+
+type AppointmentStatus = "SCHEDULED" | "COMPLETED" | "CANCELLED" | "NO_SHOW";
+
+interface Appointment {
+  id: string;
+  organizationId: string;
+  patientId: string;
+  appointmentDate: string;
+  appointmentTime: string;
+  doctor: string;
+  reason: string;
+  status: AppointmentStatus;
+  notes: string | null;
+  createdAt: string;
+  patient: {
+    id: string;
+    patientNumber: string;
+    firstName: string;
+    lastName: string;
+  };
+}
+
+const STATUS_BADGE_MAP: Record<AppointmentStatus, { label: string; variant: BadgeVariant }> = {
+  SCHEDULED: { label: "Scheduled", variant: "primary" },
+  COMPLETED: { label: "Completed", variant: "success" },
+  CANCELLED: { label: "Cancelled", variant: "danger" },
+  NO_SHOW: { label: "No Show", variant: "warning" },
+};
+
+export default function AppointmentDetailPage() {
+  const { orgId, loading: orgLoading } = useOrganization();
+  const params = useParams();
+  const router = useRouter();
+  const appointmentId = params.id as string;
+
+  const [appointment, setAppointment] = useState<Appointment | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+  const [updating, setUpdating] = useState(false);
+  const [editNotes, setEditNotes] = useState("");
+  const [showNotesInput, setShowNotesInput] = useState(false);
+
+  const fetchAppointment = useCallback(async () => {
+    if (!orgId) return;
+    setLoading(true);
+    try {
+      const data = await orgApiFetch<Appointment>(
+        `/appointments/${appointmentId}`,
+        orgId
+      );
+      setAppointment(data);
+      setEditNotes(data.notes || "");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load appointment.");
+    } finally {
+      setLoading(false);
+    }
+  }, [orgId, appointmentId]);
+
+  useEffect(() => {
+    fetchAppointment();
+  }, [fetchAppointment]);
+
+  const updateStatus = async (status: AppointmentStatus) => {
+    if (!orgId || !appointment) return;
+    setUpdating(true);
+    try {
+      const data = await orgApiFetch<Appointment>(
+        `/appointments/${appointmentId}`,
+        orgId,
+        {
+          method: "PUT",
+          body: JSON.stringify({ status }),
+        }
+      );
+      setAppointment(data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to update status.");
+    } finally {
+      setUpdating(false);
+    }
+  };
+
+  const saveNotes = async () => {
+    if (!orgId || !appointment) return;
+    setUpdating(true);
+    try {
+      const data = await orgApiFetch<Appointment>(
+        `/appointments/${appointmentId}`,
+        orgId,
+        {
+          method: "PUT",
+          body: JSON.stringify({ notes: editNotes }),
+        }
+      );
+      setAppointment(data);
+      setShowNotesInput(false);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to update notes.");
+    } finally {
+      setUpdating(false);
+    }
+  };
+
+  if (orgLoading || !orgId) {
+    return (
+      <div className="flex justify-center py-16">
+        <Spinner size="lg" />
+      </div>
+    );
+  }
+
+  if (loading) {
+    return (
+      <div className="flex justify-center py-12">
+        <Spinner size="lg" />
+      </div>
+    );
+  }
+
+  if (error && !appointment) {
+    return (
+      <div className="py-12">
+        <EmptyState
+          title="Appointment not found"
+          description={error || "The requested appointment could not be found."}
+          action={
+            <Button
+              variant="outline"
+              onClick={() => router.push("/appointments")}
+            >
+              Back to Appointments
+            </Button>
+          }
+        />
+      </div>
+    );
+  }
+
+  if (!appointment) return null;
+
+  const statusInfo = STATUS_BADGE_MAP[appointment.status];
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+        <div className="flex items-center gap-3">
+          <button
+            onClick={() => router.push("/appointments")}
+            className="p-2 rounded-lg hover:bg-gray-100 text-gray-500 transition-colors"
+          >
+            <ArrowLeft className="h-5 w-5" />
+          </button>
+          <div>
+            <h1 className="text-2xl font-bold text-gray-900">
+              Appointment Details
+            </h1>
+            <div className="flex items-center gap-2 mt-1">
+              <Badge variant={statusInfo.variant}>{statusInfo.label}</Badge>
+              <span className="text-sm text-gray-500">
+                {new Date(appointment.createdAt).toLocaleDateString()}
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Error Banner */}
+      {error && (
+        <div className="p-3 rounded-lg bg-danger-light text-danger text-sm">
+          {error}
+        </div>
+      )}
+
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        {/* Main Info */}
+        <div className="lg:col-span-2 space-y-6">
+          {/* Appointment Info Card */}
+          <Card>
+            <CardHeader>
+              <h2 className="text-lg font-semibold text-gray-900">
+                Appointment Information
+              </h2>
+            </CardHeader>
+            <CardBody className="space-y-4">
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                <div className="flex items-start gap-3">
+                  <Calendar className="h-5 w-5 text-gray-400 mt-0.5 shrink-0" />
+                  <div>
+                    <p className="text-xs text-gray-500 uppercase tracking-wider">
+                      Date
+                    </p>
+                    <p className="text-sm font-medium text-gray-900">
+                      {new Date(appointment.appointmentDate).toLocaleDateString(
+                        "en-US",
+                        {
+                          weekday: "long",
+                          year: "numeric",
+                          month: "long",
+                          day: "numeric",
+                        }
+                      )}
+                    </p>
+                  </div>
+                </div>
+                <div className="flex items-start gap-3">
+                  <Clock className="h-5 w-5 text-gray-400 mt-0.5 shrink-0" />
+                  <div>
+                    <p className="text-xs text-gray-500 uppercase tracking-wider">
+                      Time
+                    </p>
+                    <p className="text-sm font-medium text-gray-900">
+                      {appointment.appointmentTime}
+                    </p>
+                  </div>
+                </div>
+                <div className="flex items-start gap-3">
+                  <Stethoscope className="h-5 w-5 text-gray-400 mt-0.5 shrink-0" />
+                  <div>
+                    <p className="text-xs text-gray-500 uppercase tracking-wider">
+                      Doctor
+                    </p>
+                    <p className="text-sm font-medium text-gray-900">
+                      {appointment.doctor}
+                    </p>
+                  </div>
+                </div>
+                <div className="flex items-start gap-3">
+                  <FileText className="h-5 w-5 text-gray-400 mt-0.5 shrink-0" />
+                  <div>
+                    <p className="text-xs text-gray-500 uppercase tracking-wider">
+                      Reason
+                    </p>
+                    <p className="text-sm font-medium text-gray-900">
+                      {appointment.reason || "Not specified"}
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </CardBody>
+          </Card>
+
+          {/* Notes Card */}
+          <Card>
+            <CardHeader className="flex items-center justify-between">
+              <h2 className="text-lg font-semibold text-gray-900">Notes</h2>
+              {!showNotesInput && (
+                <button
+                  onClick={() => setShowNotesInput(true)}
+                  className="text-sm text-primary hover:text-primary-hover font-medium"
+                >
+                  Edit
+                </button>
+              )}
+            </CardHeader>
+            <CardBody>
+              {showNotesInput ? (
+                <div className="space-y-3">
+                  <textarea
+                    value={editNotes}
+                    onChange={(e) => setEditNotes(e.target.value)}
+                    rows={4}
+                    placeholder="Add notes about this appointment..."
+                    className="block w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 placeholder-gray-400 transition-colors focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary"
+                  />
+                  <div className="flex items-center gap-2">
+                    <Button size="sm" loading={updating} onClick={saveNotes}>
+                      Save Notes
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      onClick={() => {
+                        setShowNotesInput(false);
+                        setEditNotes(appointment.notes || "");
+                      }}
+                    >
+                      Cancel
+                    </Button>
+                  </div>
+                </div>
+              ) : (
+                <div className="flex items-start gap-3">
+                  <StickyNote className="h-5 w-5 text-gray-400 mt-0.5 shrink-0" />
+                  <p className="text-sm text-gray-700">
+                    {appointment.notes || "No notes for this appointment."}
+                  </p>
+                </div>
+              )}
+            </CardBody>
+          </Card>
+
+          {/* Status Actions */}
+          {appointment.status === "SCHEDULED" && (
+            <Card>
+              <CardHeader>
+                <h2 className="text-lg font-semibold text-gray-900">
+                  Update Status
+                </h2>
+              </CardHeader>
+              <CardBody>
+                <p className="text-sm text-gray-500 mb-4">
+                  Change the appointment status as needed.
+                </p>
+                <div className="flex flex-wrap items-center gap-3">
+                  <Button
+                    variant="primary"
+                    size="sm"
+                    loading={updating}
+                    icon={<CheckCircle2 className="h-4 w-4" />}
+                    onClick={() => updateStatus("COMPLETED")}
+                  >
+                    Mark Complete
+                  </Button>
+                  <Button
+                    variant="danger"
+                    size="sm"
+                    loading={updating}
+                    icon={<XCircle className="h-4 w-4" />}
+                    onClick={() => updateStatus("CANCELLED")}
+                  >
+                    Cancel Appointment
+                  </Button>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    loading={updating}
+                    icon={<AlertTriangle className="h-4 w-4" />}
+                    onClick={() => updateStatus("NO_SHOW")}
+                  >
+                    No Show
+                  </Button>
+                </div>
+              </CardBody>
+            </Card>
+          )}
+        </div>
+
+        {/* Sidebar - Patient Info */}
+        <div>
+          <Card>
+            <CardHeader>
+              <h2 className="text-lg font-semibold text-gray-900">
+                Patient Information
+              </h2>
+            </CardHeader>
+            <CardBody className="space-y-4">
+              <div className="flex items-center gap-3">
+                <div className="h-12 w-12 rounded-full bg-primary-light flex items-center justify-center">
+                  <User className="h-6 w-6 text-primary" />
+                </div>
+                <div>
+                  <p className="text-sm font-medium text-gray-900">
+                    {appointment.patient.firstName}{" "}
+                    {appointment.patient.lastName}
+                  </p>
+                  <p className="text-xs text-gray-500">
+                    {appointment.patient.patientNumber}
+                  </p>
+                </div>
+              </div>
+              <div className="border-t border-gray-100 pt-4">
+                <div className="flex items-start gap-3">
+                  <User className="h-5 w-5 text-gray-400 mt-0.5 shrink-0" />
+                  <div>
+                    <p className="text-xs text-gray-500 uppercase tracking-wider">
+                      Patient ID
+                    </p>
+                    <p className="text-sm font-medium text-gray-900">
+                      {appointment.patient.patientNumber}
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </CardBody>
+          </Card>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(dashboard)/appointments/new/page.tsx
+++ b/src/app/(dashboard)/appointments/new/page.tsx
@@ -1,0 +1,331 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { useRouter } from "next/navigation";
+import {
+  ArrowLeft,
+  Calendar,
+  Clock,
+  User,
+  Stethoscope,
+  FileText,
+  Search,
+} from "lucide-react";
+import { useOrganization } from "@/lib/hooks/use-organization";
+import { orgApiFetch } from "@/lib/api";
+import Card, { CardBody, CardHeader } from "@/components/ui/Card";
+import Button from "@/components/ui/Button";
+import Input from "@/components/ui/Input";
+import Spinner from "@/components/ui/Spinner";
+
+interface Patient {
+  id: string;
+  patientNumber: string;
+  firstName: string;
+  lastName: string;
+}
+
+interface PatientsResponse {
+  patients: Patient[];
+}
+
+export default function NewAppointmentPage() {
+  const { orgId, loading: orgLoading } = useOrganization();
+  const router = useRouter();
+
+  const [patients, setPatients] = useState<Patient[]>([]);
+  const [patientsLoading, setPatientsLoading] = useState(true);
+  const [patientSearch, setPatientSearch] = useState("");
+  const [showPatientDropdown, setShowPatientDropdown] = useState(false);
+
+  const [selectedPatient, setSelectedPatient] = useState<Patient | null>(null);
+  const [appointmentDate, setAppointmentDate] = useState("");
+  const [appointmentTime, setAppointmentTime] = useState("");
+  const [doctor, setDoctor] = useState("");
+  const [reason, setReason] = useState("");
+  const [notes, setNotes] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState("");
+
+  const fetchPatients = useCallback(async () => {
+    if (!orgId) return;
+    setPatientsLoading(true);
+    try {
+      const data = await orgApiFetch<PatientsResponse>(
+        "/patients?limit=100",
+        orgId
+      );
+      setPatients(data.patients);
+    } catch {
+      // silently handle
+    } finally {
+      setPatientsLoading(false);
+    }
+  }, [orgId]);
+
+  useEffect(() => {
+    fetchPatients();
+  }, [fetchPatients]);
+
+  const filteredPatients = patientSearch
+    ? patients.filter((p) => {
+        const q = patientSearch.toLowerCase();
+        const fullName = `${p.firstName} ${p.lastName}`.toLowerCase();
+        return (
+          fullName.includes(q) ||
+          p.patientNumber.toLowerCase().includes(q)
+        );
+      })
+    : patients;
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError("");
+
+    if (!selectedPatient) {
+      setError("Please select a patient.");
+      return;
+    }
+    if (!appointmentDate || !appointmentTime || !doctor) {
+      setError("Please fill in all required fields.");
+      return;
+    }
+    if (!orgId) return;
+
+    setSubmitting(true);
+    try {
+      await orgApiFetch("/appointments", orgId, {
+        method: "POST",
+        body: JSON.stringify({
+          patientId: selectedPatient.id,
+          appointmentDate,
+          appointmentTime,
+          doctor,
+          reason: reason || undefined,
+          notes: notes || undefined,
+        }),
+      });
+      router.push("/appointments");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to create appointment.");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (orgLoading || !orgId) {
+    return (
+      <div className="flex justify-center py-16">
+        <Spinner size="lg" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-2xl mx-auto space-y-6">
+      {/* Header */}
+      <div className="flex items-center gap-3">
+        <button
+          onClick={() => router.push("/appointments")}
+          className="p-2 rounded-lg hover:bg-gray-100 text-gray-500 transition-colors"
+        >
+          <ArrowLeft className="h-5 w-5" />
+        </button>
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">New Appointment</h1>
+          <p className="text-sm text-gray-500 mt-1">
+            Schedule a new patient appointment
+          </p>
+        </div>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <h2 className="text-lg font-semibold text-gray-900">
+            Appointment Details
+          </h2>
+        </CardHeader>
+        <CardBody>
+          <form onSubmit={handleSubmit} className="space-y-5">
+            {/* Patient Selector */}
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                Patient <span className="text-danger">*</span>
+              </label>
+              {selectedPatient ? (
+                <div className="flex items-center justify-between p-3 rounded-lg border border-gray-300 bg-gray-50">
+                  <div className="flex items-center gap-3">
+                    <div className="h-8 w-8 rounded-full bg-primary-light flex items-center justify-center">
+                      <User className="h-4 w-4 text-primary" />
+                    </div>
+                    <div>
+                      <p className="text-sm font-medium text-gray-900">
+                        {selectedPatient.firstName} {selectedPatient.lastName}
+                      </p>
+                      <p className="text-xs text-gray-500">
+                        {selectedPatient.patientNumber}
+                      </p>
+                    </div>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setSelectedPatient(null);
+                      setPatientSearch("");
+                    }}
+                    className="text-sm text-primary hover:text-primary-hover font-medium"
+                  >
+                    Change
+                  </button>
+                </div>
+              ) : (
+                <div className="relative">
+                  <Input
+                    placeholder="Search patients by name or number..."
+                    icon={<Search className="h-4 w-4" />}
+                    value={patientSearch}
+                    onChange={(e) => {
+                      setPatientSearch(e.target.value);
+                      setShowPatientDropdown(true);
+                    }}
+                    onFocus={() => setShowPatientDropdown(true)}
+                  />
+                  {showPatientDropdown && (
+                    <div className="absolute z-10 w-full mt-1 bg-white border border-gray-200 rounded-lg shadow-lg max-h-60 overflow-y-auto">
+                      {patientsLoading ? (
+                        <div className="flex justify-center py-4">
+                          <Spinner size="sm" />
+                        </div>
+                      ) : filteredPatients.length === 0 ? (
+                        <div className="px-4 py-3 text-sm text-gray-500">
+                          No patients found.
+                        </div>
+                      ) : (
+                        filteredPatients.map((patient) => (
+                          <button
+                            key={patient.id}
+                            type="button"
+                            onClick={() => {
+                              setSelectedPatient(patient);
+                              setShowPatientDropdown(false);
+                              setPatientSearch("");
+                            }}
+                            className="w-full flex items-center gap-3 px-4 py-3 hover:bg-gray-50 transition-colors text-left"
+                          >
+                            <div className="h-8 w-8 rounded-full bg-primary-light flex items-center justify-center shrink-0">
+                              <User className="h-4 w-4 text-primary" />
+                            </div>
+                            <div>
+                              <p className="text-sm font-medium text-gray-900">
+                                {patient.firstName} {patient.lastName}
+                              </p>
+                              <p className="text-xs text-gray-500">
+                                {patient.patientNumber}
+                              </p>
+                            </div>
+                          </button>
+                        ))
+                      )}
+                    </div>
+                  )}
+                </div>
+              )}
+            </div>
+
+            {/* Date & Time */}
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <div>
+                <Input
+                  label="Date"
+                  type="date"
+                  icon={<Calendar className="h-4 w-4" />}
+                  value={appointmentDate}
+                  onChange={(e) => setAppointmentDate(e.target.value)}
+                  required
+                />
+              </div>
+              <div>
+                <Input
+                  label="Time"
+                  type="time"
+                  icon={<Clock className="h-4 w-4" />}
+                  value={appointmentTime}
+                  onChange={(e) => setAppointmentTime(e.target.value)}
+                  required
+                />
+              </div>
+            </div>
+
+            {/* Doctor */}
+            <Input
+              label="Doctor"
+              placeholder="Dr. Smith"
+              icon={<Stethoscope className="h-4 w-4" />}
+              value={doctor}
+              onChange={(e) => setDoctor(e.target.value)}
+              required
+            />
+
+            {/* Reason */}
+            <div>
+              <label
+                htmlFor="reason"
+                className="block text-sm font-medium text-gray-700 mb-1"
+              >
+                Reason
+              </label>
+              <textarea
+                id="reason"
+                placeholder="Reason for the appointment..."
+                value={reason}
+                onChange={(e) => setReason(e.target.value)}
+                rows={3}
+                className="block w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 placeholder-gray-400 transition-colors focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary"
+              />
+            </div>
+
+            {/* Notes */}
+            <div>
+              <label
+                htmlFor="notes"
+                className="block text-sm font-medium text-gray-700 mb-1"
+              >
+                Notes
+              </label>
+              <textarea
+                id="notes"
+                placeholder="Additional notes..."
+                value={notes}
+                onChange={(e) => setNotes(e.target.value)}
+                rows={3}
+                className="block w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 placeholder-gray-400 transition-colors focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary"
+              />
+            </div>
+
+            {/* Error */}
+            {error && (
+              <div className="p-3 rounded-lg bg-danger-light text-danger text-sm">
+                {error}
+              </div>
+            )}
+
+            {/* Actions */}
+            <div className="flex items-center gap-3 pt-2">
+              <Button type="submit" loading={submitting}>
+                <Calendar className="h-4 w-4" />
+                Schedule Appointment
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => router.push("/appointments")}
+              >
+                Cancel
+              </Button>
+            </div>
+          </form>
+        </CardBody>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/(dashboard)/appointments/page.tsx
+++ b/src/app/(dashboard)/appointments/page.tsx
@@ -1,0 +1,317 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { useRouter } from "next/navigation";
+import {
+  Calendar,
+  Plus,
+  ChevronLeft,
+  ChevronRight,
+  Clock,
+  Search,
+} from "lucide-react";
+import { useOrganization } from "@/lib/hooks/use-organization";
+import { orgApiFetch } from "@/lib/api";
+import Card, { CardBody } from "@/components/ui/Card";
+import Button from "@/components/ui/Button";
+import Input from "@/components/ui/Input";
+import Badge from "@/components/ui/Badge";
+import Spinner from "@/components/ui/Spinner";
+import EmptyState from "@/components/ui/EmptyState";
+
+type BadgeVariant = "default" | "primary" | "accent" | "danger" | "warning" | "success";
+
+type AppointmentStatus = "SCHEDULED" | "COMPLETED" | "CANCELLED" | "NO_SHOW";
+
+interface Appointment {
+  id: string;
+  organizationId: string;
+  patientId: string;
+  appointmentDate: string;
+  appointmentTime: string;
+  doctor: string;
+  reason: string;
+  status: AppointmentStatus;
+  notes: string | null;
+  createdAt: string;
+  patient: {
+    id: string;
+    patientNumber: string;
+    firstName: string;
+    lastName: string;
+  };
+}
+
+interface AppointmentsResponse {
+  appointments: Appointment[];
+  pagination: {
+    page: number;
+    limit: number;
+    total: number;
+    totalPages: number;
+  };
+}
+
+const STATUS_BADGE_MAP: Record<AppointmentStatus, { label: string; variant: BadgeVariant }> = {
+  SCHEDULED: { label: "Scheduled", variant: "primary" },
+  COMPLETED: { label: "Completed", variant: "success" },
+  CANCELLED: { label: "Cancelled", variant: "danger" },
+  NO_SHOW: { label: "No Show", variant: "warning" },
+};
+
+const statusFilters: { value: string; label: string }[] = [
+  { value: "ALL", label: "All" },
+  { value: "SCHEDULED", label: "Scheduled" },
+  { value: "COMPLETED", label: "Completed" },
+  { value: "CANCELLED", label: "Cancelled" },
+  { value: "NO_SHOW", label: "No Show" },
+];
+
+const ITEMS_PER_PAGE = 20;
+
+export default function AppointmentsPage() {
+  const { orgId, loading: orgLoading } = useOrganization();
+  const router = useRouter();
+
+  const [appointments, setAppointments] = useState<Appointment[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [statusFilter, setStatusFilter] = useState("ALL");
+  const [searchQuery, setSearchQuery] = useState("");
+  const [currentPage, setCurrentPage] = useState(1);
+  const [totalPages, setTotalPages] = useState(1);
+  const [total, setTotal] = useState(0);
+
+  const fetchAppointments = useCallback(async () => {
+    if (!orgId) return;
+    setLoading(true);
+    try {
+      const params = new URLSearchParams({
+        page: String(currentPage),
+        limit: String(ITEMS_PER_PAGE),
+      });
+      if (statusFilter !== "ALL") {
+        params.set("status", statusFilter);
+      }
+      const data = await orgApiFetch<AppointmentsResponse>(
+        `/appointments?${params.toString()}`,
+        orgId
+      );
+      setAppointments(data.appointments);
+      setTotalPages(data.pagination.totalPages);
+      setTotal(data.pagination.total);
+    } catch {
+      // silently handle
+    } finally {
+      setLoading(false);
+    }
+  }, [orgId, currentPage, statusFilter]);
+
+  useEffect(() => {
+    fetchAppointments();
+  }, [fetchAppointments]);
+
+  if (orgLoading || !orgId) {
+    return (
+      <div className="flex justify-center py-16">
+        <Spinner size="lg" />
+      </div>
+    );
+  }
+
+  const filteredAppointments = searchQuery
+    ? appointments.filter((appt) => {
+        const q = searchQuery.toLowerCase();
+        const patientName = `${appt.patient.firstName} ${appt.patient.lastName}`.toLowerCase();
+        return (
+          patientName.includes(q) ||
+          appt.doctor.toLowerCase().includes(q) ||
+          (appt.reason && appt.reason.toLowerCase().includes(q))
+        );
+      })
+    : appointments;
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+        <div>
+          <div className="flex items-center gap-3 mb-1">
+            <Calendar className="h-7 w-7 text-primary" />
+            <h1 className="text-2xl font-bold text-gray-900">Appointments</h1>
+          </div>
+          <p className="text-sm text-gray-500">
+            {total} appointment{total !== 1 ? "s" : ""} found
+          </p>
+        </div>
+        <Button
+          icon={<Plus className="h-4 w-4" />}
+          onClick={() => router.push("/appointments/new")}
+        >
+          New Appointment
+        </Button>
+      </div>
+
+      {/* Status Filter Tabs */}
+      <Card>
+        <CardBody className="flex flex-col sm:flex-row gap-4 items-start sm:items-center">
+          <div className="flex-1 w-full sm:max-w-xs">
+            <Input
+              placeholder="Search by patient, doctor, reason..."
+              icon={<Search className="h-4 w-4" />}
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+            />
+          </div>
+          <div className="flex items-center gap-1 flex-wrap">
+            {statusFilters.map((filter) => (
+              <button
+                key={filter.value}
+                onClick={() => {
+                  setStatusFilter(filter.value);
+                  setCurrentPage(1);
+                }}
+                className={`px-3 py-1.5 text-sm font-medium rounded-lg transition-colors ${
+                  statusFilter === filter.value
+                    ? "bg-primary text-white"
+                    : "text-gray-500 hover:text-gray-700 hover:bg-gray-100"
+                }`}
+              >
+                {filter.label}
+              </button>
+            ))}
+          </div>
+        </CardBody>
+      </Card>
+
+      {/* Table */}
+      {loading ? (
+        <div className="flex justify-center py-12">
+          <Spinner size="lg" />
+        </div>
+      ) : filteredAppointments.length === 0 ? (
+        <EmptyState
+          icon={<Calendar className="h-16 w-16" />}
+          title="No appointments found"
+          description="Try adjusting your filters, or schedule a new appointment."
+          action={
+            <Button
+              icon={<Plus className="h-4 w-4" />}
+              onClick={() => router.push("/appointments/new")}
+            >
+              New Appointment
+            </Button>
+          }
+        />
+      ) : (
+        <Card>
+          <div className="overflow-x-auto">
+            <table className="w-full">
+              <thead>
+                <tr className="border-b border-gray-100">
+                  <th className="text-left px-6 py-3 text-xs font-medium text-gray-500 uppercase tracking-wider">
+                    Date
+                  </th>
+                  <th className="text-left px-6 py-3 text-xs font-medium text-gray-500 uppercase tracking-wider">
+                    Time
+                  </th>
+                  <th className="text-left px-6 py-3 text-xs font-medium text-gray-500 uppercase tracking-wider">
+                    Patient
+                  </th>
+                  <th className="text-left px-6 py-3 text-xs font-medium text-gray-500 uppercase tracking-wider hidden md:table-cell">
+                    Doctor
+                  </th>
+                  <th className="text-left px-6 py-3 text-xs font-medium text-gray-500 uppercase tracking-wider hidden lg:table-cell">
+                    Reason
+                  </th>
+                  <th className="text-left px-6 py-3 text-xs font-medium text-gray-500 uppercase tracking-wider">
+                    Status
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-50">
+                {filteredAppointments.map((appt) => {
+                  const statusInfo = STATUS_BADGE_MAP[appt.status];
+                  return (
+                    <tr
+                      key={appt.id}
+                      className="hover:bg-gray-50 cursor-pointer transition-colors"
+                      onClick={() => router.push(`/appointments/${appt.id}`)}
+                    >
+                      <td className="px-6 py-4">
+                        <div className="flex items-center gap-2">
+                          <Calendar className="h-4 w-4 text-gray-400 shrink-0" />
+                          <span className="text-sm text-gray-900">
+                            {new Date(appt.appointmentDate).toLocaleDateString()}
+                          </span>
+                        </div>
+                      </td>
+                      <td className="px-6 py-4">
+                        <div className="flex items-center gap-2">
+                          <Clock className="h-4 w-4 text-gray-400 shrink-0" />
+                          <span className="text-sm text-gray-900">
+                            {appt.appointmentTime}
+                          </span>
+                        </div>
+                      </td>
+                      <td className="px-6 py-4">
+                        <div>
+                          <p className="text-sm font-medium text-gray-900">
+                            {appt.patient.firstName} {appt.patient.lastName}
+                          </p>
+                          <p className="text-xs text-gray-500">
+                            {appt.patient.patientNumber}
+                          </p>
+                        </div>
+                      </td>
+                      <td className="px-6 py-4 text-sm text-gray-700 hidden md:table-cell">
+                        {appt.doctor}
+                      </td>
+                      <td className="px-6 py-4 text-sm text-gray-500 hidden lg:table-cell">
+                        {appt.reason || "-"}
+                      </td>
+                      <td className="px-6 py-4">
+                        <Badge variant={statusInfo.variant}>
+                          {statusInfo.label}
+                        </Badge>
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        </Card>
+      )}
+
+      {/* Pagination */}
+      {totalPages > 1 && (
+        <div className="flex items-center justify-between">
+          <p className="text-sm text-gray-500">
+            Showing {(currentPage - 1) * ITEMS_PER_PAGE + 1} to{" "}
+            {Math.min(currentPage * ITEMS_PER_PAGE, total)} of {total}
+          </p>
+          <div className="flex items-center gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={currentPage === 1}
+              onClick={() => setCurrentPage(currentPage - 1)}
+              icon={<ChevronLeft className="h-4 w-4" />}
+            >
+              Previous
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={currentPage === totalPages}
+              onClick={() => setCurrentPage(currentPage + 1)}
+            >
+              Next
+              <ChevronRight className="h-4 w-4" />
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/(dashboard)/eye-consultations/new/page.tsx
+++ b/src/app/(dashboard)/eye-consultations/new/page.tsx
@@ -1,0 +1,438 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import {
+  ArrowLeft,
+  Eye,
+  Save,
+  Search,
+} from "lucide-react";
+import { useOrganization } from "@/lib/hooks/use-organization";
+import { orgApiFetch } from "@/lib/api";
+import Card, { CardBody, CardHeader } from "@/components/ui/Card";
+import Button from "@/components/ui/Button";
+import Input from "@/components/ui/Input";
+import Spinner from "@/components/ui/Spinner";
+
+interface Patient {
+  id: string;
+  patientNumber: string;
+  firstName: string;
+  lastName: string;
+}
+
+interface ExamFormData {
+  patientId: string;
+  consultationDate: string;
+  doctor: string;
+  chiefComplaint: string;
+  reMovement: string;
+  leMovement: string;
+  reLids: string;
+  leLids: string;
+  reGlobe: string;
+  leGlobe: string;
+  reConjunctiva: string;
+  leConjunctiva: string;
+  reCornea: string;
+  leCornea: string;
+  reAc: string;
+  leAc: string;
+  rePupil: string;
+  lePupil: string;
+  reIris: string;
+  leIris: string;
+  reLens: string;
+  leLens: string;
+  reVrr: string;
+  leVrr: string;
+  reVcdr: string;
+  leVcdr: string;
+  reOthers: string;
+  leOthers: string;
+  diagnosis: string;
+  plan: string;
+}
+
+const BILATERAL_FIELDS: { label: string; reKey: keyof ExamFormData; leKey: keyof ExamFormData }[] = [
+  { label: "Movement", reKey: "reMovement", leKey: "leMovement" },
+  { label: "Lids", reKey: "reLids", leKey: "leLids" },
+  { label: "Globe", reKey: "reGlobe", leKey: "leGlobe" },
+  { label: "Conjunctiva", reKey: "reConjunctiva", leKey: "leConjunctiva" },
+  { label: "Cornea", reKey: "reCornea", leKey: "leCornea" },
+  { label: "AC", reKey: "reAc", leKey: "leAc" },
+  { label: "Pupil", reKey: "rePupil", leKey: "lePupil" },
+  { label: "Iris", reKey: "reIris", leKey: "leIris" },
+  { label: "Lens", reKey: "reLens", leKey: "leLens" },
+  { label: "VRR", reKey: "reVrr", leKey: "leVrr" },
+  { label: "VCDR", reKey: "reVcdr", leKey: "leVcdr" },
+  { label: "Others", reKey: "reOthers", leKey: "leOthers" },
+];
+
+const INITIAL_FORM: ExamFormData = {
+  patientId: "",
+  consultationDate: new Date().toISOString().split("T")[0],
+  doctor: "",
+  chiefComplaint: "",
+  reMovement: "",
+  leMovement: "",
+  reLids: "",
+  leLids: "",
+  reGlobe: "",
+  leGlobe: "",
+  reConjunctiva: "",
+  leConjunctiva: "",
+  reCornea: "",
+  leCornea: "",
+  reAc: "",
+  leAc: "",
+  rePupil: "",
+  lePupil: "",
+  reIris: "",
+  leIris: "",
+  reLens: "",
+  leLens: "",
+  reVrr: "",
+  leVrr: "",
+  reVcdr: "",
+  leVcdr: "",
+  reOthers: "",
+  leOthers: "",
+  diagnosis: "",
+  plan: "",
+};
+
+export default function NewEyeConsultationPage() {
+  const { orgId, loading: orgLoading } = useOrganization();
+
+  const [form, setForm] = useState<ExamFormData>(INITIAL_FORM);
+  const [patients, setPatients] = useState<Patient[]>([]);
+  const [patientsLoading, setPatientsLoading] = useState(false);
+  const [patientSearch, setPatientSearch] = useState("");
+  const [showPatientDropdown, setShowPatientDropdown] = useState(false);
+  const [selectedPatient, setSelectedPatient] = useState<Patient | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchPatients = useCallback(async () => {
+    if (!orgId) return;
+    setPatientsLoading(true);
+    try {
+      const data = await orgApiFetch<{ patients: Patient[] }>(
+        "/patients?limit=100",
+        orgId
+      );
+      setPatients(data.patients);
+    } catch {
+      // Silently handle - patients dropdown just won't populate
+    } finally {
+      setPatientsLoading(false);
+    }
+  }, [orgId]);
+
+  useEffect(() => {
+    fetchPatients();
+  }, [fetchPatients]);
+
+  const filteredPatients = patients.filter((p) => {
+    const q = patientSearch.toLowerCase();
+    return (
+      p.firstName.toLowerCase().includes(q) ||
+      p.lastName.toLowerCase().includes(q) ||
+      p.patientNumber.toLowerCase().includes(q)
+    );
+  });
+
+  const handleSelectPatient = (patient: Patient) => {
+    setSelectedPatient(patient);
+    setForm({ ...form, patientId: patient.id });
+    setPatientSearch(`${patient.firstName} ${patient.lastName} (${patient.patientNumber})`);
+    setShowPatientDropdown(false);
+  };
+
+  const updateField = (key: keyof ExamFormData, value: string) => {
+    setForm((prev) => ({ ...prev, [key]: value }));
+  };
+
+  const handleSubmit = async () => {
+    if (!orgId || !form.patientId || !form.doctor) return;
+    setSubmitting(true);
+    setError(null);
+
+    // Build body, omitting empty optional fields
+    const body: Record<string, string> = {
+      patientId: form.patientId,
+      consultationDate: form.consultationDate,
+      doctor: form.doctor,
+    };
+
+    const optionalFields: (keyof ExamFormData)[] = [
+      "chiefComplaint",
+      "reMovement", "leMovement",
+      "reLids", "leLids",
+      "reGlobe", "leGlobe",
+      "reConjunctiva", "leConjunctiva",
+      "reCornea", "leCornea",
+      "reAc", "leAc",
+      "rePupil", "lePupil",
+      "reIris", "leIris",
+      "reLens", "leLens",
+      "reVrr", "leVrr",
+      "reVcdr", "leVcdr",
+      "reOthers", "leOthers",
+      "diagnosis", "plan",
+    ];
+
+    for (const key of optionalFields) {
+      if (form[key]) {
+        body[key] = form[key];
+      }
+    }
+
+    try {
+      await orgApiFetch("/eye-consultations", orgId, {
+        method: "POST",
+        body: JSON.stringify(body),
+      });
+      window.location.href = "/eye-consultations";
+    } catch {
+      setError("Failed to create consultation. Please check your permissions and try again.");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (orgLoading || !orgId) {
+    return (
+      <div className="flex justify-center py-16">
+        <Spinner size="lg" />
+      </div>
+    );
+  }
+
+  const canSubmit = form.patientId && form.doctor && form.consultationDate;
+
+  return (
+    <div className="max-w-4xl mx-auto space-y-6">
+      {/* Header */}
+      <div className="flex items-center gap-3">
+        <button
+          onClick={() => (window.location.href = "/eye-consultations")}
+          className="p-2 rounded-lg hover:bg-gray-100 text-gray-500 transition-colors"
+        >
+          <ArrowLeft className="h-5 w-5" />
+        </button>
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">
+            New Eye Consultation
+          </h1>
+          <p className="text-sm text-gray-500 mt-0.5">
+            Record a new eye examination
+          </p>
+        </div>
+      </div>
+
+      {/* Error Banner */}
+      {error && (
+        <div className="bg-danger-light border border-danger/20 text-danger rounded-lg px-4 py-3 text-sm">
+          {error}
+        </div>
+      )}
+
+      {/* Patient & Basic Info */}
+      <Card>
+        <CardHeader>
+          <h2 className="text-lg font-semibold text-gray-900">
+            Patient & Visit Information
+          </h2>
+        </CardHeader>
+        <CardBody className="space-y-4">
+          {/* Patient selector */}
+          <div className="relative">
+            <Input
+              label="Patient"
+              placeholder="Search by name or patient number..."
+              icon={<Search className="h-4 w-4" />}
+              value={patientSearch}
+              onChange={(e) => {
+                setPatientSearch(e.target.value);
+                setShowPatientDropdown(true);
+                if (selectedPatient) {
+                  setSelectedPatient(null);
+                  setForm({ ...form, patientId: "" });
+                }
+              }}
+              onFocus={() => setShowPatientDropdown(true)}
+            />
+            {showPatientDropdown && patientSearch && (
+              <div className="absolute z-20 top-full left-0 right-0 mt-1 bg-white border border-gray-200 rounded-lg shadow-lg max-h-48 overflow-y-auto">
+                {patientsLoading ? (
+                  <div className="flex justify-center py-3">
+                    <Spinner size="sm" />
+                  </div>
+                ) : filteredPatients.length === 0 ? (
+                  <p className="text-sm text-gray-500 px-3 py-3">
+                    No patients found.
+                  </p>
+                ) : (
+                  filteredPatients.map((p) => (
+                    <button
+                      key={p.id}
+                      type="button"
+                      className="w-full text-left px-3 py-2 hover:bg-gray-50 transition-colors text-sm"
+                      onClick={() => handleSelectPatient(p)}
+                    >
+                      <span className="font-medium text-gray-900">
+                        {p.firstName} {p.lastName}
+                      </span>
+                      <span className="text-gray-500 ml-2">
+                        ({p.patientNumber})
+                      </span>
+                    </button>
+                  ))
+                )}
+              </div>
+            )}
+          </div>
+
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <Input
+              label="Consultation Date"
+              type="date"
+              value={form.consultationDate}
+              onChange={(e) => updateField("consultationDate", e.target.value)}
+            />
+            <Input
+              label="Doctor"
+              placeholder="Dr. name"
+              value={form.doctor}
+              onChange={(e) => updateField("doctor", e.target.value)}
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Chief Complaint
+            </label>
+            <textarea
+              value={form.chiefComplaint}
+              onChange={(e) => updateField("chiefComplaint", e.target.value)}
+              placeholder="Describe the chief complaint..."
+              rows={2}
+              className="block w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary"
+            />
+          </div>
+        </CardBody>
+      </Card>
+
+      {/* Bilateral Examination */}
+      <Card>
+        <CardHeader>
+          <div className="flex items-center gap-2">
+            <Eye className="h-5 w-5 text-primary" />
+            <h2 className="text-lg font-semibold text-gray-900">
+              Bilateral Examination
+            </h2>
+          </div>
+          <p className="text-sm text-gray-500 mt-0.5">
+            Enter findings for Right Eye (RE) and Left Eye (LE)
+          </p>
+        </CardHeader>
+        <CardBody>
+          {/* Column Headers */}
+          <div className="grid grid-cols-[1fr_1fr_1fr] gap-3 mb-3">
+            <div className="text-xs font-medium text-gray-500 uppercase tracking-wider">
+              Field
+            </div>
+            <div className="text-xs font-medium text-gray-500 uppercase tracking-wider text-center">
+              RE (Right Eye)
+            </div>
+            <div className="text-xs font-medium text-gray-500 uppercase tracking-wider text-center">
+              LE (Left Eye)
+            </div>
+          </div>
+
+          <div className="space-y-3">
+            {BILATERAL_FIELDS.map((field) => (
+              <div
+                key={field.label}
+                className="grid grid-cols-[1fr_1fr_1fr] gap-3 items-center"
+              >
+                <label className="text-sm font-medium text-gray-700">
+                  {field.label}
+                </label>
+                <input
+                  type="text"
+                  placeholder="RE"
+                  value={form[field.reKey]}
+                  onChange={(e) => updateField(field.reKey, e.target.value)}
+                  className="block w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary"
+                />
+                <input
+                  type="text"
+                  placeholder="LE"
+                  value={form[field.leKey]}
+                  onChange={(e) => updateField(field.leKey, e.target.value)}
+                  className="block w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary"
+                />
+              </div>
+            ))}
+          </div>
+        </CardBody>
+      </Card>
+
+      {/* Diagnosis & Plan */}
+      <Card>
+        <CardHeader>
+          <h2 className="text-lg font-semibold text-gray-900">
+            Diagnosis & Plan
+          </h2>
+        </CardHeader>
+        <CardBody className="space-y-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Diagnosis
+            </label>
+            <textarea
+              value={form.diagnosis}
+              onChange={(e) => updateField("diagnosis", e.target.value)}
+              placeholder="Enter diagnosis..."
+              rows={3}
+              className="block w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Plan
+            </label>
+            <textarea
+              value={form.plan}
+              onChange={(e) => updateField("plan", e.target.value)}
+              placeholder="Enter treatment plan..."
+              rows={3}
+              className="block w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary"
+            />
+          </div>
+        </CardBody>
+      </Card>
+
+      {/* Actions */}
+      <div className="flex items-center justify-between">
+        <Button
+          variant="outline"
+          onClick={() => (window.location.href = "/eye-consultations")}
+        >
+          Cancel
+        </Button>
+        <Button
+          icon={<Save className="h-4 w-4" />}
+          loading={submitting}
+          disabled={!canSubmit}
+          onClick={handleSubmit}
+        >
+          Save Consultation
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(dashboard)/eye-consultations/page.tsx
+++ b/src/app/(dashboard)/eye-consultations/page.tsx
@@ -1,0 +1,392 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import {
+  Eye,
+  Plus,
+  ChevronLeft,
+  ChevronRight,
+  Calendar,
+  User,
+  Stethoscope,
+  X,
+} from "lucide-react";
+import { useOrganization } from "@/lib/hooks/use-organization";
+import { orgApiFetch } from "@/lib/api";
+import Card, { CardBody, CardHeader } from "@/components/ui/Card";
+import Button from "@/components/ui/Button";
+import Badge from "@/components/ui/Badge";
+import Spinner from "@/components/ui/Spinner";
+import EmptyState from "@/components/ui/EmptyState";
+import Modal from "@/components/ui/Modal";
+
+interface Patient {
+  id: string;
+  patientNumber: string;
+  firstName: string;
+  lastName: string;
+}
+
+interface Consultation {
+  id: string;
+  consultationDate: string;
+  doctor: string;
+  chiefComplaint: string | null;
+  diagnosis: string | null;
+  plan: string | null;
+  reMovement: string | null;
+  leMovement: string | null;
+  reLids: string | null;
+  leLids: string | null;
+  reGlobe: string | null;
+  leGlobe: string | null;
+  reConjunctiva: string | null;
+  leConjunctiva: string | null;
+  reCornea: string | null;
+  leCornea: string | null;
+  reAc: string | null;
+  leAc: string | null;
+  rePupil: string | null;
+  lePupil: string | null;
+  reIris: string | null;
+  leIris: string | null;
+  reLens: string | null;
+  leLens: string | null;
+  reVrr: string | null;
+  leVrr: string | null;
+  reVcdr: string | null;
+  leVcdr: string | null;
+  reOthers: string | null;
+  leOthers: string | null;
+  patient: Patient;
+}
+
+const ITEMS_PER_PAGE = 20;
+
+const EXAM_FIELDS = [
+  { label: "Movement", re: "reMovement", le: "leMovement" },
+  { label: "Lids", re: "reLids", le: "leLids" },
+  { label: "Globe", re: "reGlobe", le: "leGlobe" },
+  { label: "Conjunctiva", re: "reConjunctiva", le: "leConjunctiva" },
+  { label: "Cornea", re: "reCornea", le: "leCornea" },
+  { label: "AC", re: "reAc", le: "leAc" },
+  { label: "Pupil", re: "rePupil", le: "lePupil" },
+  { label: "Iris", re: "reIris", le: "leIris" },
+  { label: "Lens", re: "reLens", le: "leLens" },
+  { label: "VRR", re: "reVrr", le: "leVrr" },
+  { label: "VCDR", re: "reVcdr", le: "leVcdr" },
+  { label: "Others", re: "reOthers", le: "leOthers" },
+] as const;
+
+export default function EyeConsultationsPage() {
+  const { orgId, loading: orgLoading } = useOrganization();
+
+  const [consultations, setConsultations] = useState<Consultation[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [currentPage, setCurrentPage] = useState(1);
+  const [totalCount, setTotalCount] = useState(0);
+  const [error, setError] = useState<string | null>(null);
+  const [selectedConsultation, setSelectedConsultation] = useState<Consultation | null>(null);
+
+  const totalPages = Math.ceil(totalCount / ITEMS_PER_PAGE) || 1;
+
+  const fetchConsultations = useCallback(async () => {
+    if (!orgId) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await orgApiFetch<{
+        consultations: Consultation[];
+        total: number;
+      }>(
+        `/eye-consultations?page=${currentPage}&limit=${ITEMS_PER_PAGE}`,
+        orgId
+      );
+      setConsultations(data.consultations);
+      setTotalCount(data.total);
+    } catch {
+      setError("Failed to load consultations. The eye consultation feature may not be enabled.");
+    } finally {
+      setLoading(false);
+    }
+  }, [orgId, currentPage]);
+
+  useEffect(() => {
+    fetchConsultations();
+  }, [fetchConsultations]);
+
+  if (orgLoading || !orgId) {
+    return (
+      <div className="flex justify-center py-16">
+        <Spinner size="lg" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">Eye Consultations</h1>
+          <p className="text-sm text-gray-500 mt-1">
+            {totalCount} consultation{totalCount !== 1 ? "s" : ""} recorded
+          </p>
+        </div>
+        <Button
+          icon={<Plus className="h-4 w-4" />}
+          onClick={() => (window.location.href = "/eye-consultations/new")}
+        >
+          New Consultation
+        </Button>
+      </div>
+
+      {/* Error Banner */}
+      {error && (
+        <div className="bg-danger-light border border-danger/20 text-danger rounded-lg px-4 py-3 text-sm">
+          {error}
+        </div>
+      )}
+
+      {/* Table */}
+      {loading ? (
+        <div className="flex justify-center py-12">
+          <Spinner size="lg" />
+        </div>
+      ) : consultations.length === 0 ? (
+        <EmptyState
+          icon={<Eye className="h-16 w-16" />}
+          title="No consultations yet"
+          description="Create your first eye consultation record to get started."
+          action={
+            <Button
+              icon={<Plus className="h-4 w-4" />}
+              onClick={() => (window.location.href = "/eye-consultations/new")}
+            >
+              New Consultation
+            </Button>
+          }
+        />
+      ) : (
+        <Card>
+          <div className="overflow-x-auto">
+            <table className="w-full">
+              <thead>
+                <tr className="border-b border-gray-100">
+                  <th className="text-left px-6 py-3 text-xs font-medium text-gray-500 uppercase tracking-wider">
+                    Date
+                  </th>
+                  <th className="text-left px-6 py-3 text-xs font-medium text-gray-500 uppercase tracking-wider">
+                    Patient
+                  </th>
+                  <th className="text-left px-6 py-3 text-xs font-medium text-gray-500 uppercase tracking-wider hidden md:table-cell">
+                    Doctor
+                  </th>
+                  <th className="text-left px-6 py-3 text-xs font-medium text-gray-500 uppercase tracking-wider hidden lg:table-cell">
+                    Chief Complaint
+                  </th>
+                  <th className="text-left px-6 py-3 text-xs font-medium text-gray-500 uppercase tracking-wider">
+                    Diagnosis
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-50">
+                {consultations.map((c) => (
+                  <tr
+                    key={c.id}
+                    className="hover:bg-gray-50 cursor-pointer transition-colors"
+                    onClick={() => setSelectedConsultation(c)}
+                  >
+                    <td className="px-6 py-4 text-sm text-gray-700 whitespace-nowrap">
+                      {new Date(c.consultationDate).toLocaleDateString("en-US", {
+                        month: "short",
+                        day: "numeric",
+                        year: "numeric",
+                      })}
+                    </td>
+                    <td className="px-6 py-4">
+                      <div>
+                        <p className="text-sm font-medium text-gray-900">
+                          {c.patient.firstName} {c.patient.lastName}
+                        </p>
+                        <p className="text-xs text-gray-500">
+                          {c.patient.patientNumber}
+                        </p>
+                      </div>
+                    </td>
+                    <td className="px-6 py-4 text-sm text-gray-700 hidden md:table-cell">
+                      {c.doctor}
+                    </td>
+                    <td className="px-6 py-4 text-sm text-gray-500 hidden lg:table-cell max-w-xs truncate">
+                      {c.chiefComplaint || "--"}
+                    </td>
+                    <td className="px-6 py-4">
+                      {c.diagnosis ? (
+                        <Badge variant="primary">{c.diagnosis}</Badge>
+                      ) : (
+                        <span className="text-sm text-gray-400">--</span>
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </Card>
+      )}
+
+      {/* Pagination */}
+      {totalPages > 1 && (
+        <div className="flex items-center justify-between">
+          <p className="text-sm text-gray-500">
+            Showing {(currentPage - 1) * ITEMS_PER_PAGE + 1} to{" "}
+            {Math.min(currentPage * ITEMS_PER_PAGE, totalCount)} of {totalCount}
+          </p>
+          <div className="flex items-center gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={currentPage === 1}
+              onClick={() => setCurrentPage(currentPage - 1)}
+              icon={<ChevronLeft className="h-4 w-4" />}
+            >
+              Previous
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={currentPage === totalPages}
+              onClick={() => setCurrentPage(currentPage + 1)}
+            >
+              Next
+              <ChevronRight className="h-4 w-4" />
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {/* Detail Modal */}
+      <Modal
+        open={!!selectedConsultation}
+        onClose={() => setSelectedConsultation(null)}
+        title="Consultation Details"
+        className="max-w-2xl"
+      >
+        {selectedConsultation && (
+          <div className="space-y-5 max-h-[70vh] overflow-y-auto">
+            {/* Summary row */}
+            <div className="grid grid-cols-2 gap-4">
+              <div className="flex items-center gap-2">
+                <Calendar className="h-4 w-4 text-gray-400" />
+                <div>
+                  <p className="text-xs text-gray-500">Date</p>
+                  <p className="text-sm font-medium text-gray-900">
+                    {new Date(selectedConsultation.consultationDate).toLocaleDateString()}
+                  </p>
+                </div>
+              </div>
+              <div className="flex items-center gap-2">
+                <Stethoscope className="h-4 w-4 text-gray-400" />
+                <div>
+                  <p className="text-xs text-gray-500">Doctor</p>
+                  <p className="text-sm font-medium text-gray-900">
+                    {selectedConsultation.doctor}
+                  </p>
+                </div>
+              </div>
+              <div className="flex items-center gap-2 col-span-2">
+                <User className="h-4 w-4 text-gray-400" />
+                <div>
+                  <p className="text-xs text-gray-500">Patient</p>
+                  <p className="text-sm font-medium text-gray-900">
+                    {selectedConsultation.patient.firstName}{" "}
+                    {selectedConsultation.patient.lastName}{" "}
+                    <span className="text-gray-500 font-normal">
+                      ({selectedConsultation.patient.patientNumber})
+                    </span>
+                  </p>
+                </div>
+              </div>
+            </div>
+
+            {/* Chief Complaint */}
+            {selectedConsultation.chiefComplaint && (
+              <div>
+                <h4 className="text-xs font-medium text-gray-500 uppercase tracking-wider mb-1">
+                  Chief Complaint
+                </h4>
+                <p className="text-sm text-gray-700">
+                  {selectedConsultation.chiefComplaint}
+                </p>
+              </div>
+            )}
+
+            {/* Bilateral Exam */}
+            <div>
+              <h4 className="text-xs font-medium text-gray-500 uppercase tracking-wider mb-2">
+                Bilateral Examination
+              </h4>
+              <div className="border border-gray-200 rounded-lg overflow-hidden">
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="bg-gray-50">
+                      <th className="text-left px-3 py-2 text-xs font-medium text-gray-500">
+                        Field
+                      </th>
+                      <th className="text-left px-3 py-2 text-xs font-medium text-gray-500">
+                        RE (Right)
+                      </th>
+                      <th className="text-left px-3 py-2 text-xs font-medium text-gray-500">
+                        LE (Left)
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-gray-100">
+                    {EXAM_FIELDS.map((field) => {
+                      const reVal = selectedConsultation[field.re as keyof Consultation] as string | null;
+                      const leVal = selectedConsultation[field.le as keyof Consultation] as string | null;
+                      if (!reVal && !leVal) return null;
+                      return (
+                        <tr key={field.label}>
+                          <td className="px-3 py-2 font-medium text-gray-700">
+                            {field.label}
+                          </td>
+                          <td className="px-3 py-2 text-gray-600">
+                            {reVal || "--"}
+                          </td>
+                          <td className="px-3 py-2 text-gray-600">
+                            {leVal || "--"}
+                          </td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+
+            {/* Diagnosis & Plan */}
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <div>
+                <h4 className="text-xs font-medium text-gray-500 uppercase tracking-wider mb-1">
+                  Diagnosis
+                </h4>
+                <p className="text-sm text-gray-700">
+                  {selectedConsultation.diagnosis || "Not recorded"}
+                </p>
+              </div>
+              <div>
+                <h4 className="text-xs font-medium text-gray-500 uppercase tracking-wider mb-1">
+                  Plan
+                </h4>
+                <p className="text-sm text-gray-700">
+                  {selectedConsultation.plan || "Not recorded"}
+                </p>
+              </div>
+            </div>
+          </div>
+        )}
+      </Modal>
+    </div>
+  );
+}

--- a/src/app/(dashboard)/lab-results/[id]/page.tsx
+++ b/src/app/(dashboard)/lab-results/[id]/page.tsx
@@ -1,0 +1,590 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { useParams, useRouter } from "next/navigation";
+import {
+  ArrowLeft,
+  FlaskConical,
+  Calendar,
+  User,
+  StickyNote,
+  Brain,
+  Sparkles,
+  ShieldAlert,
+  TrendingUp,
+  Clock,
+  CheckCircle2,
+  ListChecks,
+  History,
+} from "lucide-react";
+import { useOrganization } from "@/lib/hooks/use-organization";
+import { orgApiFetch } from "@/lib/api";
+import Card, { CardBody, CardHeader } from "@/components/ui/Card";
+import Button from "@/components/ui/Button";
+import Badge from "@/components/ui/Badge";
+import Spinner from "@/components/ui/Spinner";
+import EmptyState from "@/components/ui/EmptyState";
+
+type BadgeVariant = "default" | "primary" | "accent" | "danger" | "warning" | "success";
+
+interface LabResult {
+  id: string;
+  organizationId: string;
+  patientId: string;
+  testName: string;
+  resultValue: string;
+  unit: string | null;
+  referenceRange: string | null;
+  datePerformed: string;
+  notes: string | null;
+  interpretationStatus: string | null;
+  interpretationText: string | null;
+  riskLevel: string | null;
+  confidence: number | null;
+  recommendations: string[] | null;
+  interpretedAt: string | null;
+  createdAt: string;
+  patient: {
+    id: string;
+    patientNumber: string;
+    firstName: string;
+    lastName: string;
+  };
+}
+
+interface InterpretationHistory {
+  id: string;
+  interpretationText: string;
+  riskLevel: string;
+  confidence: number;
+  recommendations: string[];
+  createdAt: string;
+}
+
+const RISK_LEVEL_BADGE_MAP: Record<string, { label: string; variant: BadgeVariant }> = {
+  NORMAL: { label: "Normal", variant: "success" },
+  LOW: { label: "Low", variant: "primary" },
+  MODERATE: { label: "Moderate", variant: "warning" },
+  HIGH: { label: "High", variant: "danger" },
+  CRITICAL: { label: "Critical", variant: "danger" },
+};
+
+export default function LabResultDetailPage() {
+  const { orgId, loading: orgLoading } = useOrganization();
+  const params = useParams();
+  const router = useRouter();
+  const resultId = params.id as string;
+
+  const [labResult, setLabResult] = useState<LabResult | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  const [interpreting, setInterpreting] = useState(false);
+  const [interpretationHistory, setInterpretationHistory] = useState<InterpretationHistory[]>([]);
+  const [historyLoading, setHistoryLoading] = useState(false);
+  const [showHistory, setShowHistory] = useState(false);
+
+  const fetchLabResult = useCallback(async () => {
+    if (!orgId) return;
+    setLoading(true);
+    try {
+      const data = await orgApiFetch<LabResult>(
+        `/lab-results/${resultId}`,
+        orgId
+      );
+      setLabResult(data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load lab result.");
+    } finally {
+      setLoading(false);
+    }
+  }, [orgId, resultId]);
+
+  useEffect(() => {
+    fetchLabResult();
+  }, [fetchLabResult]);
+
+  const triggerInterpretation = async () => {
+    if (!orgId) return;
+    setInterpreting(true);
+    setError("");
+    try {
+      const data = await orgApiFetch<LabResult>(
+        `/lab-results/${resultId}/interpret`,
+        orgId,
+        { method: "POST" }
+      );
+      setLabResult(data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to interpret lab result.");
+    } finally {
+      setInterpreting(false);
+    }
+  };
+
+  const fetchHistory = async () => {
+    if (!orgId) return;
+    setHistoryLoading(true);
+    try {
+      const data = await orgApiFetch<InterpretationHistory[]>(
+        `/lab-results/${resultId}/interpret`,
+        orgId
+      );
+      setInterpretationHistory(Array.isArray(data) ? data : []);
+    } catch {
+      // silently handle
+    } finally {
+      setHistoryLoading(false);
+    }
+  };
+
+  const toggleHistory = () => {
+    if (!showHistory && interpretationHistory.length === 0) {
+      fetchHistory();
+    }
+    setShowHistory(!showHistory);
+  };
+
+  if (orgLoading || !orgId) {
+    return (
+      <div className="flex justify-center py-16">
+        <Spinner size="lg" />
+      </div>
+    );
+  }
+
+  if (loading) {
+    return (
+      <div className="flex justify-center py-12">
+        <Spinner size="lg" />
+      </div>
+    );
+  }
+
+  if (error && !labResult) {
+    return (
+      <div className="py-12">
+        <EmptyState
+          title="Lab result not found"
+          description={error || "The requested lab result could not be found."}
+          action={
+            <Button
+              variant="outline"
+              onClick={() => router.push("/lab-results")}
+            >
+              Back to Lab Results
+            </Button>
+          }
+        />
+      </div>
+    );
+  }
+
+  if (!labResult) return null;
+
+  const riskInfo = labResult.riskLevel
+    ? RISK_LEVEL_BADGE_MAP[labResult.riskLevel]
+    : null;
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+        <div className="flex items-center gap-3">
+          <button
+            onClick={() => router.push("/lab-results")}
+            className="p-2 rounded-lg hover:bg-gray-100 text-gray-500 transition-colors"
+          >
+            <ArrowLeft className="h-5 w-5" />
+          </button>
+          <div>
+            <h1 className="text-2xl font-bold text-gray-900">
+              {labResult.testName}
+            </h1>
+            <div className="flex items-center gap-2 mt-1">
+              {riskInfo && (
+                <Badge variant={riskInfo.variant}>{riskInfo.label} Risk</Badge>
+              )}
+              <span className="text-sm text-gray-500">
+                {new Date(labResult.datePerformed).toLocaleDateString()}
+              </span>
+            </div>
+          </div>
+        </div>
+        {!labResult.interpretedAt && (
+          <Button
+            icon={<Brain className="h-4 w-4" />}
+            loading={interpreting}
+            onClick={triggerInterpretation}
+          >
+            Interpret with AI
+          </Button>
+        )}
+      </div>
+
+      {/* Error Banner */}
+      {error && (
+        <div className="p-3 rounded-lg bg-danger-light text-danger text-sm">
+          {error}
+        </div>
+      )}
+
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        {/* Main Content */}
+        <div className="lg:col-span-2 space-y-6">
+          {/* Lab Result Info */}
+          <Card>
+            <CardHeader>
+              <h2 className="text-lg font-semibold text-gray-900">
+                Lab Result Information
+              </h2>
+            </CardHeader>
+            <CardBody className="space-y-4">
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                <div className="flex items-start gap-3">
+                  <FlaskConical className="h-5 w-5 text-gray-400 mt-0.5 shrink-0" />
+                  <div>
+                    <p className="text-xs text-gray-500 uppercase tracking-wider">
+                      Test Name
+                    </p>
+                    <p className="text-sm font-medium text-gray-900">
+                      {labResult.testName}
+                    </p>
+                  </div>
+                </div>
+                <div className="flex items-start gap-3">
+                  <TrendingUp className="h-5 w-5 text-gray-400 mt-0.5 shrink-0" />
+                  <div>
+                    <p className="text-xs text-gray-500 uppercase tracking-wider">
+                      Result
+                    </p>
+                    <p className="text-sm font-medium text-gray-900">
+                      {labResult.resultValue}
+                      {labResult.unit && (
+                        <span className="text-gray-500 ml-1">
+                          {labResult.unit}
+                        </span>
+                      )}
+                    </p>
+                  </div>
+                </div>
+                <div className="flex items-start gap-3">
+                  <ShieldAlert className="h-5 w-5 text-gray-400 mt-0.5 shrink-0" />
+                  <div>
+                    <p className="text-xs text-gray-500 uppercase tracking-wider">
+                      Reference Range
+                    </p>
+                    <p className="text-sm font-medium text-gray-900">
+                      {labResult.referenceRange || "Not specified"}
+                    </p>
+                  </div>
+                </div>
+                <div className="flex items-start gap-3">
+                  <Calendar className="h-5 w-5 text-gray-400 mt-0.5 shrink-0" />
+                  <div>
+                    <p className="text-xs text-gray-500 uppercase tracking-wider">
+                      Date Performed
+                    </p>
+                    <p className="text-sm font-medium text-gray-900">
+                      {new Date(labResult.datePerformed).toLocaleDateString(
+                        "en-US",
+                        {
+                          weekday: "long",
+                          year: "numeric",
+                          month: "long",
+                          day: "numeric",
+                        }
+                      )}
+                    </p>
+                  </div>
+                </div>
+              </div>
+              {labResult.notes && (
+                <div className="border-t border-gray-100 pt-4">
+                  <div className="flex items-start gap-3">
+                    <StickyNote className="h-5 w-5 text-gray-400 mt-0.5 shrink-0" />
+                    <div>
+                      <p className="text-xs text-gray-500 uppercase tracking-wider">
+                        Notes
+                      </p>
+                      <p className="text-sm text-gray-700 mt-1">
+                        {labResult.notes}
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              )}
+            </CardBody>
+          </Card>
+
+          {/* AI Interpretation */}
+          {interpreting ? (
+            <Card>
+              <CardBody>
+                <div className="flex flex-col items-center justify-center py-12">
+                  <div className="relative mb-4">
+                    <Brain className="h-12 w-12 text-primary" />
+                    <Sparkles className="h-5 w-5 text-warning absolute -top-1 -right-1 animate-pulse" />
+                  </div>
+                  <h3 className="text-lg font-medium text-gray-900 mb-2">
+                    Analyzing Lab Result...
+                  </h3>
+                  <p className="text-sm text-gray-500 mb-4">
+                    Our AI is interpreting the lab result. This may take a moment.
+                  </p>
+                  <Spinner size="md" />
+                </div>
+              </CardBody>
+            </Card>
+          ) : labResult.interpretedAt ? (
+            <Card>
+              <CardHeader className="flex items-center justify-between">
+                <div className="flex items-center gap-2">
+                  <Brain className="h-5 w-5 text-primary" />
+                  <h2 className="text-lg font-semibold text-gray-900">
+                    AI Interpretation
+                  </h2>
+                </div>
+                <div className="flex items-center gap-2">
+                  <CheckCircle2 className="h-4 w-4 text-success" />
+                  <span className="text-xs text-gray-500">
+                    Interpreted{" "}
+                    {new Date(labResult.interpretedAt).toLocaleDateString()}
+                  </span>
+                </div>
+              </CardHeader>
+              <CardBody className="space-y-5">
+                {/* Risk Level & Confidence */}
+                <div className="flex flex-wrap items-center gap-4">
+                  {riskInfo && (
+                    <div className="flex items-center gap-2">
+                      <span className="text-sm text-gray-500">Risk Level:</span>
+                      <Badge variant={riskInfo.variant}>
+                        {riskInfo.label}
+                      </Badge>
+                    </div>
+                  )}
+                  {labResult.confidence !== null && (
+                    <div className="flex items-center gap-2">
+                      <span className="text-sm text-gray-500">Confidence:</span>
+                      <div className="flex items-center gap-2">
+                        <div className="w-24 h-2 bg-gray-200 rounded-full overflow-hidden">
+                          <div
+                            className="h-full bg-primary rounded-full transition-all"
+                            style={{ width: `${labResult.confidence}%` }}
+                          />
+                        </div>
+                        <span className="text-sm font-medium text-gray-900">
+                          {labResult.confidence}%
+                        </span>
+                      </div>
+                    </div>
+                  )}
+                </div>
+
+                {/* Interpretation Text */}
+                {labResult.interpretationText && (
+                  <div>
+                    <h3 className="text-sm font-semibold text-gray-900 mb-2">
+                      Summary
+                    </h3>
+                    <p className="text-sm text-gray-700 leading-relaxed">
+                      {labResult.interpretationText}
+                    </p>
+                  </div>
+                )}
+
+                {/* Recommendations */}
+                {labResult.recommendations &&
+                  labResult.recommendations.length > 0 && (
+                    <div>
+                      <div className="flex items-center gap-2 mb-3">
+                        <ListChecks className="h-4 w-4 text-primary" />
+                        <h3 className="text-sm font-semibold text-gray-900">
+                          Recommendations
+                        </h3>
+                      </div>
+                      <ul className="space-y-2">
+                        {labResult.recommendations.map((rec, idx) => (
+                          <li
+                            key={idx}
+                            className="flex items-start gap-3 text-sm text-gray-700"
+                          >
+                            <span className="mt-0.5 w-5 h-5 rounded-full bg-primary-light text-primary flex items-center justify-center text-xs font-medium shrink-0">
+                              {idx + 1}
+                            </span>
+                            <span>{rec}</span>
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  )}
+
+                {/* Re-interpret Button */}
+                <div className="border-t border-gray-100 pt-4">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    icon={<Brain className="h-4 w-4" />}
+                    loading={interpreting}
+                    onClick={triggerInterpretation}
+                  >
+                    Re-interpret with AI
+                  </Button>
+                </div>
+              </CardBody>
+            </Card>
+          ) : (
+            <Card>
+              <CardBody>
+                <div className="flex flex-col items-center justify-center py-12">
+                  <Brain className="h-12 w-12 text-gray-300 mb-4" />
+                  <h3 className="text-lg font-medium text-gray-900 mb-2">
+                    No AI Interpretation Yet
+                  </h3>
+                  <p className="text-sm text-gray-500 mb-6 max-w-sm text-center">
+                    Use AI to analyze this lab result and get risk assessment,
+                    clinical insights, and recommendations.
+                  </p>
+                  <Button
+                    icon={<Brain className="h-4 w-4" />}
+                    onClick={triggerInterpretation}
+                  >
+                    Interpret with AI
+                  </Button>
+                </div>
+              </CardBody>
+            </Card>
+          )}
+
+          {/* Interpretation History */}
+          <Card>
+            <CardHeader>
+              <button
+                onClick={toggleHistory}
+                className="flex items-center gap-2 w-full text-left"
+              >
+                <History className="h-5 w-5 text-gray-400" />
+                <h2 className="text-lg font-semibold text-gray-900">
+                  Interpretation History
+                </h2>
+              </button>
+            </CardHeader>
+            {showHistory && (
+              <CardBody>
+                {historyLoading ? (
+                  <div className="flex justify-center py-6">
+                    <Spinner size="md" />
+                  </div>
+                ) : interpretationHistory.length === 0 ? (
+                  <p className="text-sm text-gray-500 py-4 text-center">
+                    No interpretation history available.
+                  </p>
+                ) : (
+                  <div className="space-y-4">
+                    {interpretationHistory.map((entry, idx) => {
+                      const entryRisk = entry.riskLevel
+                        ? RISK_LEVEL_BADGE_MAP[entry.riskLevel]
+                        : null;
+                      return (
+                        <div
+                          key={entry.id || idx}
+                          className="p-4 rounded-lg border border-gray-100 bg-gray-50"
+                        >
+                          <div className="flex items-center justify-between mb-2">
+                            <div className="flex items-center gap-2">
+                              {entryRisk && (
+                                <Badge variant={entryRisk.variant}>
+                                  {entryRisk.label}
+                                </Badge>
+                              )}
+                              <span className="text-xs text-gray-500">
+                                Confidence: {entry.confidence}%
+                              </span>
+                            </div>
+                            <div className="flex items-center gap-1 text-xs text-gray-400">
+                              <Clock className="h-3 w-3" />
+                              {new Date(entry.createdAt).toLocaleDateString()}{" "}
+                              {new Date(entry.createdAt).toLocaleTimeString()}
+                            </div>
+                          </div>
+                          <p className="text-sm text-gray-700 mb-2">
+                            {entry.interpretationText}
+                          </p>
+                          {entry.recommendations &&
+                            entry.recommendations.length > 0 && (
+                              <ul className="space-y-1">
+                                {entry.recommendations.map((rec, ridx) => (
+                                  <li
+                                    key={ridx}
+                                    className="text-xs text-gray-500 flex items-start gap-2"
+                                  >
+                                    <span className="mt-0.5 w-1.5 h-1.5 rounded-full bg-gray-300 shrink-0" />
+                                    {rec}
+                                  </li>
+                                ))}
+                              </ul>
+                            )}
+                        </div>
+                      );
+                    })}
+                  </div>
+                )}
+              </CardBody>
+            )}
+          </Card>
+        </div>
+
+        {/* Sidebar - Patient Info */}
+        <div>
+          <Card>
+            <CardHeader>
+              <h2 className="text-lg font-semibold text-gray-900">
+                Patient Information
+              </h2>
+            </CardHeader>
+            <CardBody className="space-y-4">
+              <div className="flex items-center gap-3">
+                <div className="h-12 w-12 rounded-full bg-primary-light flex items-center justify-center">
+                  <User className="h-6 w-6 text-primary" />
+                </div>
+                <div>
+                  <p className="text-sm font-medium text-gray-900">
+                    {labResult.patient.firstName} {labResult.patient.lastName}
+                  </p>
+                  <p className="text-xs text-gray-500">
+                    {labResult.patient.patientNumber}
+                  </p>
+                </div>
+              </div>
+              <div className="border-t border-gray-100 pt-4 space-y-3">
+                <div className="flex items-start gap-3">
+                  <User className="h-5 w-5 text-gray-400 mt-0.5 shrink-0" />
+                  <div>
+                    <p className="text-xs text-gray-500 uppercase tracking-wider">
+                      Patient ID
+                    </p>
+                    <p className="text-sm font-medium text-gray-900">
+                      {labResult.patient.patientNumber}
+                    </p>
+                  </div>
+                </div>
+                <div className="flex items-start gap-3">
+                  <Clock className="h-5 w-5 text-gray-400 mt-0.5 shrink-0" />
+                  <div>
+                    <p className="text-xs text-gray-500 uppercase tracking-wider">
+                      Record Created
+                    </p>
+                    <p className="text-sm font-medium text-gray-900">
+                      {new Date(labResult.createdAt).toLocaleDateString()}
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </CardBody>
+          </Card>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(dashboard)/lab-results/new/page.tsx
+++ b/src/app/(dashboard)/lab-results/new/page.tsx
@@ -1,0 +1,324 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { useRouter } from "next/navigation";
+import {
+  ArrowLeft,
+  FlaskConical,
+  Calendar,
+  User,
+  Search,
+} from "lucide-react";
+import { useOrganization } from "@/lib/hooks/use-organization";
+import { orgApiFetch } from "@/lib/api";
+import Card, { CardBody, CardHeader } from "@/components/ui/Card";
+import Button from "@/components/ui/Button";
+import Input from "@/components/ui/Input";
+import Spinner from "@/components/ui/Spinner";
+
+interface Patient {
+  id: string;
+  patientNumber: string;
+  firstName: string;
+  lastName: string;
+}
+
+interface PatientsResponse {
+  patients: Patient[];
+}
+
+export default function NewLabResultPage() {
+  const { orgId, loading: orgLoading } = useOrganization();
+  const router = useRouter();
+
+  const [patients, setPatients] = useState<Patient[]>([]);
+  const [patientsLoading, setPatientsLoading] = useState(true);
+  const [patientSearch, setPatientSearch] = useState("");
+  const [showPatientDropdown, setShowPatientDropdown] = useState(false);
+
+  const [selectedPatient, setSelectedPatient] = useState<Patient | null>(null);
+  const [testName, setTestName] = useState("");
+  const [resultValue, setResultValue] = useState("");
+  const [unit, setUnit] = useState("");
+  const [referenceRange, setReferenceRange] = useState("");
+  const [datePerformed, setDatePerformed] = useState("");
+  const [notes, setNotes] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState("");
+
+  const fetchPatients = useCallback(async () => {
+    if (!orgId) return;
+    setPatientsLoading(true);
+    try {
+      const data = await orgApiFetch<PatientsResponse>(
+        "/patients?limit=100",
+        orgId
+      );
+      setPatients(data.patients);
+    } catch {
+      // silently handle
+    } finally {
+      setPatientsLoading(false);
+    }
+  }, [orgId]);
+
+  useEffect(() => {
+    fetchPatients();
+  }, [fetchPatients]);
+
+  const filteredPatients = patientSearch
+    ? patients.filter((p) => {
+        const q = patientSearch.toLowerCase();
+        const fullName = `${p.firstName} ${p.lastName}`.toLowerCase();
+        return (
+          fullName.includes(q) ||
+          p.patientNumber.toLowerCase().includes(q)
+        );
+      })
+    : patients;
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError("");
+
+    if (!selectedPatient) {
+      setError("Please select a patient.");
+      return;
+    }
+    if (!testName || !resultValue || !datePerformed) {
+      setError("Please fill in all required fields.");
+      return;
+    }
+    if (!orgId) return;
+
+    setSubmitting(true);
+    try {
+      await orgApiFetch("/lab-results", orgId, {
+        method: "POST",
+        body: JSON.stringify({
+          patientId: selectedPatient.id,
+          testName,
+          resultValue,
+          unit: unit || undefined,
+          referenceRange: referenceRange || undefined,
+          datePerformed,
+          notes: notes || undefined,
+        }),
+      });
+      router.push("/lab-results");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to create lab result.");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (orgLoading || !orgId) {
+    return (
+      <div className="flex justify-center py-16">
+        <Spinner size="lg" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-2xl mx-auto space-y-6">
+      {/* Header */}
+      <div className="flex items-center gap-3">
+        <button
+          onClick={() => router.push("/lab-results")}
+          className="p-2 rounded-lg hover:bg-gray-100 text-gray-500 transition-colors"
+        >
+          <ArrowLeft className="h-5 w-5" />
+        </button>
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">New Lab Result</h1>
+          <p className="text-sm text-gray-500 mt-1">
+            Record a new lab result for a patient
+          </p>
+        </div>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <h2 className="text-lg font-semibold text-gray-900">
+            Lab Result Details
+          </h2>
+        </CardHeader>
+        <CardBody>
+          <form onSubmit={handleSubmit} className="space-y-5">
+            {/* Patient Selector */}
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                Patient <span className="text-danger">*</span>
+              </label>
+              {selectedPatient ? (
+                <div className="flex items-center justify-between p-3 rounded-lg border border-gray-300 bg-gray-50">
+                  <div className="flex items-center gap-3">
+                    <div className="h-8 w-8 rounded-full bg-primary-light flex items-center justify-center">
+                      <User className="h-4 w-4 text-primary" />
+                    </div>
+                    <div>
+                      <p className="text-sm font-medium text-gray-900">
+                        {selectedPatient.firstName} {selectedPatient.lastName}
+                      </p>
+                      <p className="text-xs text-gray-500">
+                        {selectedPatient.patientNumber}
+                      </p>
+                    </div>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setSelectedPatient(null);
+                      setPatientSearch("");
+                    }}
+                    className="text-sm text-primary hover:text-primary-hover font-medium"
+                  >
+                    Change
+                  </button>
+                </div>
+              ) : (
+                <div className="relative">
+                  <Input
+                    placeholder="Search patients by name or number..."
+                    icon={<Search className="h-4 w-4" />}
+                    value={patientSearch}
+                    onChange={(e) => {
+                      setPatientSearch(e.target.value);
+                      setShowPatientDropdown(true);
+                    }}
+                    onFocus={() => setShowPatientDropdown(true)}
+                  />
+                  {showPatientDropdown && (
+                    <div className="absolute z-10 w-full mt-1 bg-white border border-gray-200 rounded-lg shadow-lg max-h-60 overflow-y-auto">
+                      {patientsLoading ? (
+                        <div className="flex justify-center py-4">
+                          <Spinner size="sm" />
+                        </div>
+                      ) : filteredPatients.length === 0 ? (
+                        <div className="px-4 py-3 text-sm text-gray-500">
+                          No patients found.
+                        </div>
+                      ) : (
+                        filteredPatients.map((patient) => (
+                          <button
+                            key={patient.id}
+                            type="button"
+                            onClick={() => {
+                              setSelectedPatient(patient);
+                              setShowPatientDropdown(false);
+                              setPatientSearch("");
+                            }}
+                            className="w-full flex items-center gap-3 px-4 py-3 hover:bg-gray-50 transition-colors text-left"
+                          >
+                            <div className="h-8 w-8 rounded-full bg-primary-light flex items-center justify-center shrink-0">
+                              <User className="h-4 w-4 text-primary" />
+                            </div>
+                            <div>
+                              <p className="text-sm font-medium text-gray-900">
+                                {patient.firstName} {patient.lastName}
+                              </p>
+                              <p className="text-xs text-gray-500">
+                                {patient.patientNumber}
+                              </p>
+                            </div>
+                          </button>
+                        ))
+                      )}
+                    </div>
+                  )}
+                </div>
+              )}
+            </div>
+
+            {/* Test Name */}
+            <Input
+              label="Test Name"
+              placeholder="e.g., Complete Blood Count, Lipid Panel"
+              icon={<FlaskConical className="h-4 w-4" />}
+              value={testName}
+              onChange={(e) => setTestName(e.target.value)}
+              required
+            />
+
+            {/* Result Value & Unit */}
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <Input
+                label="Result Value"
+                placeholder="e.g., 120"
+                value={resultValue}
+                onChange={(e) => setResultValue(e.target.value)}
+                required
+              />
+              <Input
+                label="Unit"
+                placeholder="e.g., mg/dL"
+                value={unit}
+                onChange={(e) => setUnit(e.target.value)}
+              />
+            </div>
+
+            {/* Reference Range */}
+            <Input
+              label="Reference Range"
+              placeholder="e.g., 70-100 mg/dL"
+              value={referenceRange}
+              onChange={(e) => setReferenceRange(e.target.value)}
+            />
+
+            {/* Date Performed */}
+            <Input
+              label="Date Performed"
+              type="date"
+              icon={<Calendar className="h-4 w-4" />}
+              value={datePerformed}
+              onChange={(e) => setDatePerformed(e.target.value)}
+              required
+            />
+
+            {/* Notes */}
+            <div>
+              <label
+                htmlFor="notes"
+                className="block text-sm font-medium text-gray-700 mb-1"
+              >
+                Notes
+              </label>
+              <textarea
+                id="notes"
+                placeholder="Additional notes about this lab result..."
+                value={notes}
+                onChange={(e) => setNotes(e.target.value)}
+                rows={3}
+                className="block w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 placeholder-gray-400 transition-colors focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary"
+              />
+            </div>
+
+            {/* Error */}
+            {error && (
+              <div className="p-3 rounded-lg bg-danger-light text-danger text-sm">
+                {error}
+              </div>
+            )}
+
+            {/* Actions */}
+            <div className="flex items-center gap-3 pt-2">
+              <Button type="submit" loading={submitting}>
+                <FlaskConical className="h-4 w-4" />
+                Save Lab Result
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => router.push("/lab-results")}
+              >
+                Cancel
+              </Button>
+            </div>
+          </form>
+        </CardBody>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/(dashboard)/lab-results/page.tsx
+++ b/src/app/(dashboard)/lab-results/page.tsx
@@ -1,0 +1,322 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { useRouter } from "next/navigation";
+import {
+  FlaskConical,
+  Plus,
+  ChevronLeft,
+  ChevronRight,
+  Search,
+  Brain,
+  Calendar,
+} from "lucide-react";
+import { useOrganization } from "@/lib/hooks/use-organization";
+import { orgApiFetch } from "@/lib/api";
+import Card, { CardBody } from "@/components/ui/Card";
+import Button from "@/components/ui/Button";
+import Input from "@/components/ui/Input";
+import Badge from "@/components/ui/Badge";
+import Spinner from "@/components/ui/Spinner";
+import EmptyState from "@/components/ui/EmptyState";
+
+type BadgeVariant = "default" | "primary" | "accent" | "danger" | "warning" | "success";
+
+interface LabResult {
+  id: string;
+  organizationId: string;
+  patientId: string;
+  testName: string;
+  resultValue: string;
+  unit: string | null;
+  referenceRange: string | null;
+  datePerformed: string;
+  notes: string | null;
+  interpretationStatus: string | null;
+  interpretationText: string | null;
+  riskLevel: string | null;
+  confidence: number | null;
+  recommendations: string[] | null;
+  interpretedAt: string | null;
+  createdAt: string;
+  patient: {
+    id: string;
+    patientNumber: string;
+    firstName: string;
+    lastName: string;
+  };
+}
+
+interface LabResultsResponse {
+  results: LabResult[];
+  pagination: {
+    page: number;
+    limit: number;
+    total: number;
+    totalPages: number;
+  };
+}
+
+const RISK_LEVEL_BADGE_MAP: Record<string, { label: string; variant: BadgeVariant }> = {
+  NORMAL: { label: "Normal", variant: "success" },
+  LOW: { label: "Low", variant: "primary" },
+  MODERATE: { label: "Moderate", variant: "warning" },
+  HIGH: { label: "High", variant: "danger" },
+  CRITICAL: { label: "Critical", variant: "danger" },
+};
+
+const ITEMS_PER_PAGE = 20;
+
+export default function LabResultsPage() {
+  const { orgId, loading: orgLoading } = useOrganization();
+  const router = useRouter();
+
+  const [results, setResults] = useState<LabResult[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [currentPage, setCurrentPage] = useState(1);
+  const [totalPages, setTotalPages] = useState(1);
+  const [total, setTotal] = useState(0);
+
+  const fetchResults = useCallback(async () => {
+    if (!orgId) return;
+    setLoading(true);
+    try {
+      const params = new URLSearchParams({
+        page: String(currentPage),
+        limit: String(ITEMS_PER_PAGE),
+      });
+      const data = await orgApiFetch<LabResultsResponse>(
+        `/lab-results?${params.toString()}`,
+        orgId
+      );
+      setResults(data.results);
+      setTotalPages(data.pagination.totalPages);
+      setTotal(data.pagination.total);
+    } catch {
+      // silently handle
+    } finally {
+      setLoading(false);
+    }
+  }, [orgId, currentPage]);
+
+  useEffect(() => {
+    fetchResults();
+  }, [fetchResults]);
+
+  if (orgLoading || !orgId) {
+    return (
+      <div className="flex justify-center py-16">
+        <Spinner size="lg" />
+      </div>
+    );
+  }
+
+  const filteredResults = searchQuery
+    ? results.filter((r) => {
+        const q = searchQuery.toLowerCase();
+        const patientName = `${r.patient.firstName} ${r.patient.lastName}`.toLowerCase();
+        return (
+          r.testName.toLowerCase().includes(q) ||
+          patientName.includes(q) ||
+          (r.resultValue && r.resultValue.toLowerCase().includes(q))
+        );
+      })
+    : results;
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+        <div>
+          <div className="flex items-center gap-3 mb-1">
+            <FlaskConical className="h-7 w-7 text-primary" />
+            <h1 className="text-2xl font-bold text-gray-900">Lab Results</h1>
+          </div>
+          <p className="text-sm text-gray-500">
+            {total} result{total !== 1 ? "s" : ""} found
+          </p>
+        </div>
+        <Button
+          icon={<Plus className="h-4 w-4" />}
+          onClick={() => router.push("/lab-results/new")}
+        >
+          New Lab Result
+        </Button>
+      </div>
+
+      {/* Search */}
+      <Card>
+        <CardBody className="flex flex-col sm:flex-row gap-4 items-start sm:items-center">
+          <div className="flex-1 w-full sm:max-w-xs">
+            <Input
+              placeholder="Search by test name, patient..."
+              icon={<Search className="h-4 w-4" />}
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+            />
+          </div>
+        </CardBody>
+      </Card>
+
+      {/* Table */}
+      {loading ? (
+        <div className="flex justify-center py-12">
+          <Spinner size="lg" />
+        </div>
+      ) : filteredResults.length === 0 ? (
+        <EmptyState
+          icon={<FlaskConical className="h-16 w-16" />}
+          title="No lab results found"
+          description="Try adjusting your search or add a new lab result."
+          action={
+            <Button
+              icon={<Plus className="h-4 w-4" />}
+              onClick={() => router.push("/lab-results/new")}
+            >
+              New Lab Result
+            </Button>
+          }
+        />
+      ) : (
+        <Card>
+          <div className="overflow-x-auto">
+            <table className="w-full">
+              <thead>
+                <tr className="border-b border-gray-100">
+                  <th className="text-left px-6 py-3 text-xs font-medium text-gray-500 uppercase tracking-wider">
+                    Date
+                  </th>
+                  <th className="text-left px-6 py-3 text-xs font-medium text-gray-500 uppercase tracking-wider">
+                    Test Name
+                  </th>
+                  <th className="text-left px-6 py-3 text-xs font-medium text-gray-500 uppercase tracking-wider">
+                    Result
+                  </th>
+                  <th className="text-left px-6 py-3 text-xs font-medium text-gray-500 uppercase tracking-wider hidden md:table-cell">
+                    Patient
+                  </th>
+                  <th className="text-left px-6 py-3 text-xs font-medium text-gray-500 uppercase tracking-wider">
+                    Risk Level
+                  </th>
+                  <th className="text-left px-6 py-3 text-xs font-medium text-gray-500 uppercase tracking-wider hidden lg:table-cell">
+                    AI Status
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-50">
+                {filteredResults.map((result) => {
+                  const riskInfo = result.riskLevel
+                    ? RISK_LEVEL_BADGE_MAP[result.riskLevel]
+                    : null;
+                  return (
+                    <tr
+                      key={result.id}
+                      className="hover:bg-gray-50 cursor-pointer transition-colors"
+                      onClick={() => router.push(`/lab-results/${result.id}`)}
+                    >
+                      <td className="px-6 py-4">
+                        <div className="flex items-center gap-2">
+                          <Calendar className="h-4 w-4 text-gray-400 shrink-0" />
+                          <span className="text-sm text-gray-900">
+                            {new Date(result.datePerformed).toLocaleDateString()}
+                          </span>
+                        </div>
+                      </td>
+                      <td className="px-6 py-4">
+                        <p className="text-sm font-medium text-gray-900">
+                          {result.testName}
+                        </p>
+                      </td>
+                      <td className="px-6 py-4">
+                        <p className="text-sm text-gray-900">
+                          {result.resultValue}
+                          {result.unit && (
+                            <span className="text-gray-500 ml-1">
+                              {result.unit}
+                            </span>
+                          )}
+                        </p>
+                        {result.referenceRange && (
+                          <p className="text-xs text-gray-400">
+                            Ref: {result.referenceRange}
+                          </p>
+                        )}
+                      </td>
+                      <td className="px-6 py-4 hidden md:table-cell">
+                        <div>
+                          <p className="text-sm font-medium text-gray-900">
+                            {result.patient.firstName} {result.patient.lastName}
+                          </p>
+                          <p className="text-xs text-gray-500">
+                            {result.patient.patientNumber}
+                          </p>
+                        </div>
+                      </td>
+                      <td className="px-6 py-4">
+                        {riskInfo ? (
+                          <Badge variant={riskInfo.variant}>
+                            {riskInfo.label}
+                          </Badge>
+                        ) : (
+                          <Badge variant="default">Pending</Badge>
+                        )}
+                      </td>
+                      <td className="px-6 py-4 hidden lg:table-cell">
+                        {result.interpretedAt ? (
+                          <div className="flex items-center gap-1.5">
+                            <Brain className="h-4 w-4 text-success" />
+                            <span className="text-sm text-success font-medium">
+                              Interpreted
+                            </span>
+                          </div>
+                        ) : (
+                          <div className="flex items-center gap-1.5">
+                            <Brain className="h-4 w-4 text-gray-300" />
+                            <span className="text-sm text-gray-400">
+                              Not interpreted
+                            </span>
+                          </div>
+                        )}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        </Card>
+      )}
+
+      {/* Pagination */}
+      {totalPages > 1 && (
+        <div className="flex items-center justify-between">
+          <p className="text-sm text-gray-500">
+            Showing {(currentPage - 1) * ITEMS_PER_PAGE + 1} to{" "}
+            {Math.min(currentPage * ITEMS_PER_PAGE, total)} of {total}
+          </p>
+          <div className="flex items-center gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={currentPage === 1}
+              onClick={() => setCurrentPage(currentPage - 1)}
+              icon={<ChevronLeft className="h-4 w-4" />}
+            >
+              Previous
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={currentPage === totalPages}
+              onClick={() => setCurrentPage(currentPage + 1)}
+            >
+              Next
+              <ChevronRight className="h-4 w-4" />
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/(dashboard)/medical-history/page.tsx
+++ b/src/app/(dashboard)/medical-history/page.tsx
@@ -1,0 +1,565 @@
+"use client";
+
+import { Suspense, useState, useEffect, useCallback } from "react";
+import { useSearchParams } from "next/navigation";
+import {
+  Search,
+  ClipboardList,
+  Plus,
+  Clock,
+  Pill,
+  Heart,
+  FileText,
+  ChevronDown,
+  ChevronUp,
+  Save,
+} from "lucide-react";
+import { useOrganization } from "@/lib/hooks/use-organization";
+import { orgApiFetch } from "@/lib/api";
+import Card, { CardBody, CardHeader, CardFooter } from "@/components/ui/Card";
+import Button from "@/components/ui/Button";
+import Input from "@/components/ui/Input";
+import Badge from "@/components/ui/Badge";
+import Spinner from "@/components/ui/Spinner";
+import EmptyState from "@/components/ui/EmptyState";
+
+interface Patient {
+  id: string;
+  patientNumber: string;
+  firstName: string;
+  lastName: string;
+}
+
+interface CurrentPatient {
+  medicalConditions: string | null;
+  medications: string | null;
+  notes: string | null;
+}
+
+interface HistoryEntry {
+  id: string;
+  medicalConditions: string | null;
+  medications: string | null;
+  notes: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export default function MedicalHistoryPage() {
+  return (
+    <Suspense fallback={<div className="flex justify-center py-16"><Spinner size="lg" /></div>}>
+      <MedicalHistoryContent />
+    </Suspense>
+  );
+}
+
+function MedicalHistoryContent() {
+  const { orgId, loading: orgLoading } = useOrganization();
+  const searchParams = useSearchParams();
+  const urlPatientId = searchParams.get("patientId");
+
+  // Patient selection state
+  const [patients, setPatients] = useState<Patient[]>([]);
+  const [patientsLoading, setPatientsLoading] = useState(false);
+  const [patientSearch, setPatientSearch] = useState("");
+  const [showPatientDropdown, setShowPatientDropdown] = useState(false);
+  const [selectedPatientId, setSelectedPatientId] = useState<string>(urlPatientId || "");
+  const [selectedPatient, setSelectedPatient] = useState<Patient | null>(null);
+
+  // History state
+  const [currentPatient, setCurrentPatient] = useState<CurrentPatient | null>(null);
+  const [entries, setEntries] = useState<HistoryEntry[]>([]);
+  const [historyLoading, setHistoryLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Add entry form state
+  const [showAddForm, setShowAddForm] = useState(false);
+  const [newConditions, setNewConditions] = useState("");
+  const [newMedications, setNewMedications] = useState("");
+  const [newNotes, setNewNotes] = useState("");
+  const [addingEntry, setAddingEntry] = useState(false);
+
+  // Expanded entries
+  const [expandedEntries, setExpandedEntries] = useState<Set<string>>(new Set());
+
+  const fetchPatients = useCallback(async () => {
+    if (!orgId) return;
+    setPatientsLoading(true);
+    try {
+      const data = await orgApiFetch<{ patients: Patient[] }>(
+        "/patients?limit=100",
+        orgId
+      );
+      setPatients(data.patients);
+      // If we have a URL patient ID, find and select it
+      if (urlPatientId) {
+        const match = data.patients.find((p) => p.id === urlPatientId);
+        if (match) {
+          setSelectedPatient(match);
+          setPatientSearch(`${match.firstName} ${match.lastName} (${match.patientNumber})`);
+        }
+      }
+    } catch {
+      // Silently handle
+    } finally {
+      setPatientsLoading(false);
+    }
+  }, [orgId, urlPatientId]);
+
+  const fetchHistory = useCallback(async () => {
+    if (!orgId || !selectedPatientId) return;
+    setHistoryLoading(true);
+    setError(null);
+    try {
+      const data = await orgApiFetch<{
+        entries: HistoryEntry[];
+        currentPatient: CurrentPatient;
+      }>(`/medical-history?patientId=${selectedPatientId}`, orgId);
+      setEntries(data.entries);
+      setCurrentPatient(data.currentPatient);
+    } catch {
+      setError("Failed to load medical history. The medical history feature may not be enabled.");
+    } finally {
+      setHistoryLoading(false);
+    }
+  }, [orgId, selectedPatientId]);
+
+  useEffect(() => {
+    fetchPatients();
+  }, [fetchPatients]);
+
+  useEffect(() => {
+    if (selectedPatientId) {
+      fetchHistory();
+    }
+  }, [selectedPatientId, fetchHistory]);
+
+  const filteredPatients = patients.filter((p) => {
+    const q = patientSearch.toLowerCase();
+    return (
+      p.firstName.toLowerCase().includes(q) ||
+      p.lastName.toLowerCase().includes(q) ||
+      p.patientNumber.toLowerCase().includes(q)
+    );
+  });
+
+  const handleSelectPatient = (patient: Patient) => {
+    setSelectedPatient(patient);
+    setSelectedPatientId(patient.id);
+    setPatientSearch(`${patient.firstName} ${patient.lastName} (${patient.patientNumber})`);
+    setShowPatientDropdown(false);
+  };
+
+  const handleAddEntry = async () => {
+    if (!orgId || !selectedPatientId) return;
+    if (!newConditions && !newMedications && !newNotes) return;
+    setAddingEntry(true);
+    setError(null);
+
+    const body: Record<string, string> = { patientId: selectedPatientId };
+    if (newConditions) body.medicalConditions = newConditions;
+    if (newMedications) body.medications = newMedications;
+    if (newNotes) body.notes = newNotes;
+
+    try {
+      await orgApiFetch("/medical-history", orgId, {
+        method: "POST",
+        body: JSON.stringify(body),
+      });
+      setNewConditions("");
+      setNewMedications("");
+      setNewNotes("");
+      setShowAddForm(false);
+      fetchHistory();
+    } catch {
+      setError("Failed to add history entry. Check your permissions and try again.");
+    } finally {
+      setAddingEntry(false);
+    }
+  };
+
+  const toggleExpanded = (id: string) => {
+    setExpandedEntries((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  };
+
+  if (orgLoading || !orgId) {
+    return (
+      <div className="flex justify-center py-16">
+        <Spinner size="lg" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div>
+        <h1 className="text-2xl font-bold text-gray-900">Medical History</h1>
+        <p className="text-sm text-gray-500 mt-1">
+          View and manage patient medical history records.
+        </p>
+      </div>
+
+      {/* Error Banner */}
+      {error && (
+        <div className="bg-danger-light border border-danger/20 text-danger rounded-lg px-4 py-3 text-sm">
+          {error}
+          <button
+            className="ml-2 underline text-xs"
+            onClick={() => setError(null)}
+          >
+            Dismiss
+          </button>
+        </div>
+      )}
+
+      {/* Patient Selector */}
+      <Card>
+        <CardBody>
+          <div className="relative">
+            <Input
+              label="Select Patient"
+              placeholder="Search by name or patient number..."
+              icon={<Search className="h-4 w-4" />}
+              value={patientSearch}
+              onChange={(e) => {
+                setPatientSearch(e.target.value);
+                setShowPatientDropdown(true);
+                if (selectedPatient) {
+                  setSelectedPatient(null);
+                  setSelectedPatientId("");
+                  setEntries([]);
+                  setCurrentPatient(null);
+                }
+              }}
+              onFocus={() => setShowPatientDropdown(true)}
+            />
+            {showPatientDropdown && patientSearch && !selectedPatient && (
+              <div className="absolute z-20 top-full left-0 right-0 mt-1 bg-white border border-gray-200 rounded-lg shadow-lg max-h-48 overflow-y-auto">
+                {patientsLoading ? (
+                  <div className="flex justify-center py-3">
+                    <Spinner size="sm" />
+                  </div>
+                ) : filteredPatients.length === 0 ? (
+                  <p className="text-sm text-gray-500 px-3 py-3">
+                    No patients found.
+                  </p>
+                ) : (
+                  filteredPatients.map((p) => (
+                    <button
+                      key={p.id}
+                      type="button"
+                      className="w-full text-left px-3 py-2 hover:bg-gray-50 transition-colors text-sm"
+                      onClick={() => handleSelectPatient(p)}
+                    >
+                      <span className="font-medium text-gray-900">
+                        {p.firstName} {p.lastName}
+                      </span>
+                      <span className="text-gray-500 ml-2">
+                        ({p.patientNumber})
+                      </span>
+                    </button>
+                  ))
+                )}
+              </div>
+            )}
+          </div>
+        </CardBody>
+      </Card>
+
+      {/* No patient selected */}
+      {!selectedPatientId && (
+        <EmptyState
+          icon={<ClipboardList className="h-16 w-16" />}
+          title="Select a Patient"
+          description="Search and select a patient above to view their medical history."
+        />
+      )}
+
+      {/* Loading History */}
+      {selectedPatientId && historyLoading && (
+        <div className="flex justify-center py-12">
+          <Spinner size="lg" />
+        </div>
+      )}
+
+      {/* Patient History Content */}
+      {selectedPatientId && !historyLoading && (
+        <>
+          {/* Current Patient Info Card */}
+          {currentPatient && (
+            <Card>
+              <CardHeader>
+                <div className="flex items-center justify-between">
+                  <div>
+                    <h2 className="text-lg font-semibold text-gray-900">
+                      Current Patient Summary
+                    </h2>
+                    {selectedPatient && (
+                      <p className="text-sm text-gray-500 mt-0.5">
+                        {selectedPatient.firstName} {selectedPatient.lastName} --{" "}
+                        {selectedPatient.patientNumber}
+                      </p>
+                    )}
+                  </div>
+                  <Badge variant="primary">Active</Badge>
+                </div>
+              </CardHeader>
+              <CardBody>
+                <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+                  <div>
+                    <div className="flex items-center gap-2 mb-2">
+                      <Heart className="h-4 w-4 text-danger" />
+                      <h3 className="text-sm font-medium text-gray-700">
+                        Medical Conditions
+                      </h3>
+                    </div>
+                    <p className="text-sm text-gray-600">
+                      {currentPatient.medicalConditions || "None recorded"}
+                    </p>
+                  </div>
+                  <div>
+                    <div className="flex items-center gap-2 mb-2">
+                      <Pill className="h-4 w-4 text-accent" />
+                      <h3 className="text-sm font-medium text-gray-700">
+                        Medications
+                      </h3>
+                    </div>
+                    <p className="text-sm text-gray-600">
+                      {currentPatient.medications || "None recorded"}
+                    </p>
+                  </div>
+                  <div>
+                    <div className="flex items-center gap-2 mb-2">
+                      <FileText className="h-4 w-4 text-primary" />
+                      <h3 className="text-sm font-medium text-gray-700">
+                        Notes
+                      </h3>
+                    </div>
+                    <p className="text-sm text-gray-600">
+                      {currentPatient.notes || "No notes"}
+                    </p>
+                  </div>
+                </div>
+              </CardBody>
+            </Card>
+          )}
+
+          {/* Add Entry Button / Form */}
+          {!showAddForm ? (
+            <div className="flex justify-end">
+              <Button
+                icon={<Plus className="h-4 w-4" />}
+                onClick={() => setShowAddForm(true)}
+              >
+                Add Entry
+              </Button>
+            </div>
+          ) : (
+            <Card>
+              <CardHeader>
+                <h2 className="text-lg font-semibold text-gray-900">
+                  New History Entry
+                </h2>
+              </CardHeader>
+              <CardBody className="space-y-4">
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">
+                    Medical Conditions
+                  </label>
+                  <textarea
+                    value={newConditions}
+                    onChange={(e) => setNewConditions(e.target.value)}
+                    placeholder="List medical conditions..."
+                    rows={2}
+                    className="block w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary"
+                  />
+                </div>
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">
+                    Medications
+                  </label>
+                  <textarea
+                    value={newMedications}
+                    onChange={(e) => setNewMedications(e.target.value)}
+                    placeholder="List current medications..."
+                    rows={2}
+                    className="block w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary"
+                  />
+                </div>
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">
+                    Notes
+                  </label>
+                  <textarea
+                    value={newNotes}
+                    onChange={(e) => setNewNotes(e.target.value)}
+                    placeholder="Additional notes..."
+                    rows={2}
+                    className="block w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary"
+                  />
+                </div>
+              </CardBody>
+              <CardFooter className="flex justify-end gap-2">
+                <Button
+                  variant="outline"
+                  onClick={() => {
+                    setShowAddForm(false);
+                    setNewConditions("");
+                    setNewMedications("");
+                    setNewNotes("");
+                  }}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  icon={<Save className="h-4 w-4" />}
+                  loading={addingEntry}
+                  disabled={!newConditions && !newMedications && !newNotes}
+                  onClick={handleAddEntry}
+                >
+                  Save Entry
+                </Button>
+              </CardFooter>
+            </Card>
+          )}
+
+          {/* Timeline */}
+          <Card>
+            <CardHeader>
+              <h2 className="text-lg font-semibold text-gray-900">
+                History Timeline
+              </h2>
+              <p className="text-sm text-gray-500 mt-0.5">
+                {entries.length} entr{entries.length !== 1 ? "ies" : "y"} recorded
+              </p>
+            </CardHeader>
+            <CardBody>
+              {entries.length === 0 ? (
+                <p className="text-sm text-gray-500 text-center py-8">
+                  No history entries yet. Add one to get started.
+                </p>
+              ) : (
+                <div className="space-y-0">
+                  {entries.map((entry, i) => {
+                    const isExpanded = expandedEntries.has(entry.id);
+                    return (
+                      <div key={entry.id} className="flex gap-4">
+                        {/* Timeline line */}
+                        <div className="flex flex-col items-center">
+                          <div className="h-3 w-3 rounded-full bg-primary mt-1.5 shrink-0" />
+                          {i < entries.length - 1 && (
+                            <div className="w-px flex-1 bg-gray-200" />
+                          )}
+                        </div>
+
+                        {/* Entry content */}
+                        <div className="flex-1 pb-6">
+                          <button
+                            className="w-full text-left"
+                            onClick={() => toggleExpanded(entry.id)}
+                          >
+                            <div className="flex items-center justify-between">
+                              <div className="flex items-center gap-2">
+                                <Clock className="h-3.5 w-3.5 text-gray-400" />
+                                <span className="text-sm font-medium text-gray-900">
+                                  {new Date(entry.createdAt).toLocaleDateString("en-US", {
+                                    year: "numeric",
+                                    month: "long",
+                                    day: "numeric",
+                                    hour: "2-digit",
+                                    minute: "2-digit",
+                                  })}
+                                </span>
+                              </div>
+                              {isExpanded ? (
+                                <ChevronUp className="h-4 w-4 text-gray-400" />
+                              ) : (
+                                <ChevronDown className="h-4 w-4 text-gray-400" />
+                              )}
+                            </div>
+
+                            {/* Summary line (always visible) */}
+                            {!isExpanded && (
+                              <p className="text-sm text-gray-500 mt-1 truncate">
+                                {[
+                                  entry.medicalConditions && `Conditions: ${entry.medicalConditions}`,
+                                  entry.medications && `Meds: ${entry.medications}`,
+                                  entry.notes,
+                                ]
+                                  .filter(Boolean)
+                                  .join(" | ") || "No details recorded"}
+                              </p>
+                            )}
+                          </button>
+
+                          {/* Expanded detail */}
+                          {isExpanded && (
+                            <div className="mt-3 space-y-3 bg-gray-50 rounded-lg p-4">
+                              {entry.medicalConditions && (
+                                <div>
+                                  <div className="flex items-center gap-1.5 mb-1">
+                                    <Heart className="h-3.5 w-3.5 text-danger" />
+                                    <span className="text-xs font-medium text-gray-500 uppercase tracking-wider">
+                                      Medical Conditions
+                                    </span>
+                                  </div>
+                                  <p className="text-sm text-gray-700">
+                                    {entry.medicalConditions}
+                                  </p>
+                                </div>
+                              )}
+                              {entry.medications && (
+                                <div>
+                                  <div className="flex items-center gap-1.5 mb-1">
+                                    <Pill className="h-3.5 w-3.5 text-accent" />
+                                    <span className="text-xs font-medium text-gray-500 uppercase tracking-wider">
+                                      Medications
+                                    </span>
+                                  </div>
+                                  <p className="text-sm text-gray-700">
+                                    {entry.medications}
+                                  </p>
+                                </div>
+                              )}
+                              {entry.notes && (
+                                <div>
+                                  <div className="flex items-center gap-1.5 mb-1">
+                                    <FileText className="h-3.5 w-3.5 text-primary" />
+                                    <span className="text-xs font-medium text-gray-500 uppercase tracking-wider">
+                                      Notes
+                                    </span>
+                                  </div>
+                                  <p className="text-sm text-gray-700">
+                                    {entry.notes}
+                                  </p>
+                                </div>
+                              )}
+                              {!entry.medicalConditions && !entry.medications && !entry.notes && (
+                                <p className="text-sm text-gray-500">
+                                  No details recorded for this entry.
+                                </p>
+                              )}
+                            </div>
+                          )}
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              )}
+            </CardBody>
+          </Card>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/app/(dashboard)/patients/[id]/page.tsx
+++ b/src/app/(dashboard)/patients/[id]/page.tsx
@@ -1,0 +1,718 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { useParams } from "next/navigation";
+import {
+  ArrowLeft,
+  Edit3,
+  Save,
+  X,
+  User,
+  Phone,
+  Mail,
+  MapPin,
+  Calendar,
+  Heart,
+  AlertTriangle,
+  Pill,
+  StickyNote,
+  ShieldAlert,
+  CalendarCheck,
+  FlaskConical,
+  ClipboardList,
+} from "lucide-react";
+import { useOrganization } from "@/lib/hooks/use-organization";
+import { orgApiFetch, ApiError } from "@/lib/api";
+import Card, { CardBody, CardHeader } from "@/components/ui/Card";
+import Button from "@/components/ui/Button";
+import Input from "@/components/ui/Input";
+import Spinner from "@/components/ui/Spinner";
+import EmptyState from "@/components/ui/EmptyState";
+import Badge from "@/components/ui/Badge";
+
+interface Patient {
+  id: string;
+  organizationId: string;
+  patientNumber: string;
+  firstName: string;
+  lastName: string;
+  dateOfBirth: string;
+  gender: "MALE" | "FEMALE" | "OTHER";
+  phone: string | null;
+  email: string | null;
+  address: string | null;
+  emergencyContact: string | null;
+  emergencyPhone: string | null;
+  allergies: string | null;
+  medicalConditions: string | null;
+  medications: string | null;
+  notes: string | null;
+  linkedUserId: string | null;
+  createdAt: string;
+  updatedAt: string;
+  appointments?: Array<{ id: string; appointmentDate: string; status: string; reason: string | null }>;
+  labResults?: Array<{ id: string; testName: string; datePerformed: string; status: string }>;
+  medicalHistories?: Array<{ id: string; createdAt: string }>;
+  eyeConsultations?: Array<{ id: string; consultationDate: string }>;
+}
+
+interface EditFormData {
+  firstName: string;
+  lastName: string;
+  dateOfBirth: string;
+  gender: string;
+  phone: string;
+  email: string;
+  address: string;
+  emergencyContact: string;
+  emergencyPhone: string;
+  allergies: string;
+  medicalConditions: string;
+  medications: string;
+  notes: string;
+}
+
+const GENDER_BADGE: Record<string, { label: string; variant: "primary" | "accent" | "default" }> = {
+  MALE: { label: "Male", variant: "primary" },
+  FEMALE: { label: "Female", variant: "accent" },
+  OTHER: { label: "Other", variant: "default" },
+};
+
+export default function PatientDetailPage() {
+  const params = useParams();
+  const patientId = params.id as string;
+  const { orgId, loading: orgLoading } = useOrganization();
+  const [patient, setPatient] = useState<Patient | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [editing, setEditing] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [formData, setFormData] = useState<EditFormData>({
+    firstName: "",
+    lastName: "",
+    dateOfBirth: "",
+    gender: "",
+    phone: "",
+    email: "",
+    address: "",
+    emergencyContact: "",
+    emergencyPhone: "",
+    allergies: "",
+    medicalConditions: "",
+    medications: "",
+    notes: "",
+  });
+
+  const fetchPatient = useCallback(async () => {
+    if (!orgId) return;
+    setLoading(true);
+    try {
+      const data = await orgApiFetch<{ patient: Patient }>(
+        `/patients/${patientId}`,
+        orgId
+      );
+      setPatient(data.patient);
+      populateForm(data.patient);
+    } catch (err) {
+      if (err instanceof ApiError) {
+        setError(err.message);
+      } else {
+        setError("Failed to load patient details.");
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, [orgId, patientId]);
+
+  useEffect(() => {
+    fetchPatient();
+  }, [fetchPatient]);
+
+  const populateForm = (p: Patient) => {
+    setFormData({
+      firstName: p.firstName,
+      lastName: p.lastName,
+      dateOfBirth: p.dateOfBirth ? p.dateOfBirth.split("T")[0] : "",
+      gender: p.gender,
+      phone: p.phone || "",
+      email: p.email || "",
+      address: p.address || "",
+      emergencyContact: p.emergencyContact || "",
+      emergencyPhone: p.emergencyPhone || "",
+      allergies: p.allergies || "",
+      medicalConditions: p.medicalConditions || "",
+      medications: p.medications || "",
+      notes: p.notes || "",
+    });
+  };
+
+  const updateField = (field: keyof EditFormData, value: string) => {
+    setFormData((prev) => ({ ...prev, [field]: value }));
+  };
+
+  const handleCancel = () => {
+    if (patient) populateForm(patient);
+    setEditing(false);
+    setSaveError(null);
+  };
+
+  const handleSave = async () => {
+    if (!orgId || !patient) return;
+    setSaving(true);
+    setSaveError(null);
+
+    try {
+      const payload: Record<string, string> = {};
+      // Only send changed fields
+      if (formData.firstName !== patient.firstName)
+        payload.firstName = formData.firstName;
+      if (formData.lastName !== patient.lastName)
+        payload.lastName = formData.lastName;
+      if (formData.dateOfBirth !== (patient.dateOfBirth?.split("T")[0] || ""))
+        payload.dateOfBirth = formData.dateOfBirth;
+      if (formData.gender !== patient.gender) payload.gender = formData.gender;
+      if (formData.phone !== (patient.phone || ""))
+        payload.phone = formData.phone;
+      if (formData.email !== (patient.email || ""))
+        payload.email = formData.email;
+      if (formData.address !== (patient.address || ""))
+        payload.address = formData.address;
+      if (formData.emergencyContact !== (patient.emergencyContact || ""))
+        payload.emergencyContact = formData.emergencyContact;
+      if (formData.emergencyPhone !== (patient.emergencyPhone || ""))
+        payload.emergencyPhone = formData.emergencyPhone;
+      if (formData.allergies !== (patient.allergies || ""))
+        payload.allergies = formData.allergies;
+      if (formData.medicalConditions !== (patient.medicalConditions || ""))
+        payload.medicalConditions = formData.medicalConditions;
+      if (formData.medications !== (patient.medications || ""))
+        payload.medications = formData.medications;
+      if (formData.notes !== (patient.notes || ""))
+        payload.notes = formData.notes;
+
+      if (Object.keys(payload).length === 0) {
+        setEditing(false);
+        return;
+      }
+
+      const data = await orgApiFetch<{ patient: Patient }>(
+        `/patients/${patientId}`,
+        orgId,
+        {
+          method: "PUT",
+          body: JSON.stringify(payload),
+        }
+      );
+
+      setPatient(data.patient);
+      populateForm(data.patient);
+      setEditing(false);
+    } catch (err) {
+      if (err instanceof ApiError) {
+        setSaveError(err.message);
+      } else {
+        setSaveError("Failed to save changes. Please try again.");
+      }
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (orgLoading || !orgId) {
+    return (
+      <div className="flex justify-center py-16">
+        <Spinner size="lg" />
+      </div>
+    );
+  }
+
+  if (loading) {
+    return (
+      <div className="flex justify-center py-12">
+        <Spinner size="lg" />
+      </div>
+    );
+  }
+
+  if (error || !patient) {
+    return (
+      <div className="py-12">
+        <EmptyState
+          title="Patient not found"
+          description={error || "The requested patient could not be found."}
+          action={
+            <Button
+              variant="outline"
+              onClick={() => (window.location.href = "/patients")}
+            >
+              Back to Patients
+            </Button>
+          }
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+        <div className="flex items-center gap-3">
+          <button
+            onClick={() => (window.location.href = "/patients")}
+            className="p-2 rounded-lg hover:bg-gray-100 text-gray-500 transition-colors"
+          >
+            <ArrowLeft className="h-5 w-5" />
+          </button>
+          <div>
+            <div className="flex items-center gap-2">
+              <h1 className="text-2xl font-bold text-gray-900">
+                {patient.firstName} {patient.lastName}
+              </h1>
+              <Badge variant={GENDER_BADGE[patient.gender]?.variant || "default"}>
+                {GENDER_BADGE[patient.gender]?.label || patient.gender}
+              </Badge>
+            </div>
+            <p className="text-sm text-gray-500 mt-0.5 font-mono">
+              {patient.patientNumber}
+            </p>
+          </div>
+        </div>
+        <div className="flex items-center gap-2">
+          {editing ? (
+            <>
+              <Button variant="outline" size="sm" onClick={handleCancel}>
+                <X className="h-4 w-4 mr-1" />
+                Cancel
+              </Button>
+              <Button
+                size="sm"
+                loading={saving}
+                onClick={handleSave}
+                icon={<Save className="h-4 w-4" />}
+              >
+                Save Changes
+              </Button>
+            </>
+          ) : (
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setEditing(true)}
+              icon={<Edit3 className="h-4 w-4" />}
+            >
+              Edit
+            </Button>
+          )}
+        </div>
+      </div>
+
+      {/* Save Error */}
+      {saveError && (
+        <div className="bg-danger-light border border-danger/20 rounded-xl px-4 py-3">
+          <p className="text-sm text-danger font-medium">{saveError}</p>
+        </div>
+      )}
+
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        {/* Main Info */}
+        <div className="lg:col-span-2 space-y-6">
+          {/* Personal Information */}
+          <Card>
+            <CardHeader>
+              <div className="flex items-center gap-2">
+                <User className="h-5 w-5 text-primary" />
+                <h2 className="text-lg font-semibold text-gray-900">
+                  Personal Information
+                </h2>
+              </div>
+            </CardHeader>
+            <CardBody>
+              {editing ? (
+                <div className="space-y-4">
+                  <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                    <Input
+                      label="First Name"
+                      value={formData.firstName}
+                      onChange={(e) => updateField("firstName", e.target.value)}
+                    />
+                    <Input
+                      label="Last Name"
+                      value={formData.lastName}
+                      onChange={(e) => updateField("lastName", e.target.value)}
+                    />
+                  </div>
+                  <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                    <Input
+                      label="Date of Birth"
+                      type="date"
+                      value={formData.dateOfBirth}
+                      onChange={(e) =>
+                        updateField("dateOfBirth", e.target.value)
+                      }
+                    />
+                    <div className="w-full">
+                      <label className="block text-sm font-medium text-gray-700 mb-1">
+                        Gender
+                      </label>
+                      <select
+                        value={formData.gender}
+                        onChange={(e) => updateField("gender", e.target.value)}
+                        className="block w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary"
+                      >
+                        <option value="MALE">Male</option>
+                        <option value="FEMALE">Female</option>
+                        <option value="OTHER">Other</option>
+                      </select>
+                    </div>
+                  </div>
+                  <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                    <Input
+                      label="Phone"
+                      type="tel"
+                      value={formData.phone}
+                      onChange={(e) => updateField("phone", e.target.value)}
+                    />
+                    <Input
+                      label="Email"
+                      type="email"
+                      value={formData.email}
+                      onChange={(e) => updateField("email", e.target.value)}
+                    />
+                  </div>
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700 mb-1">
+                      Address
+                    </label>
+                    <textarea
+                      value={formData.address}
+                      onChange={(e) => updateField("address", e.target.value)}
+                      rows={2}
+                      className="block w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary"
+                    />
+                  </div>
+                </div>
+              ) : (
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
+                  <InfoRow
+                    icon={<Calendar className="h-5 w-5" />}
+                    label="Date of Birth"
+                    value={new Date(patient.dateOfBirth).toLocaleDateString(
+                      "en-US",
+                      { year: "numeric", month: "long", day: "numeric" }
+                    )}
+                  />
+                  <InfoRow
+                    icon={<Phone className="h-5 w-5" />}
+                    label="Phone"
+                    value={patient.phone}
+                  />
+                  <InfoRow
+                    icon={<Mail className="h-5 w-5" />}
+                    label="Email"
+                    value={patient.email}
+                  />
+                  <InfoRow
+                    icon={<MapPin className="h-5 w-5" />}
+                    label="Address"
+                    value={patient.address}
+                  />
+                </div>
+              )}
+            </CardBody>
+          </Card>
+
+          {/* Medical Information */}
+          <Card>
+            <CardHeader>
+              <div className="flex items-center gap-2">
+                <Heart className="h-5 w-5 text-accent" />
+                <h2 className="text-lg font-semibold text-gray-900">
+                  Medical Information
+                </h2>
+              </div>
+            </CardHeader>
+            <CardBody>
+              {editing ? (
+                <div className="space-y-4">
+                  <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                    <Input
+                      label="Emergency Contact"
+                      value={formData.emergencyContact}
+                      onChange={(e) =>
+                        updateField("emergencyContact", e.target.value)
+                      }
+                    />
+                    <Input
+                      label="Emergency Phone"
+                      type="tel"
+                      value={formData.emergencyPhone}
+                      onChange={(e) =>
+                        updateField("emergencyPhone", e.target.value)
+                      }
+                    />
+                  </div>
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700 mb-1">
+                      Allergies
+                    </label>
+                    <textarea
+                      value={formData.allergies}
+                      onChange={(e) => updateField("allergies", e.target.value)}
+                      rows={2}
+                      className="block w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary"
+                    />
+                  </div>
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700 mb-1">
+                      Medical Conditions
+                    </label>
+                    <textarea
+                      value={formData.medicalConditions}
+                      onChange={(e) =>
+                        updateField("medicalConditions", e.target.value)
+                      }
+                      rows={3}
+                      className="block w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary"
+                    />
+                  </div>
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700 mb-1">
+                      Medications
+                    </label>
+                    <textarea
+                      value={formData.medications}
+                      onChange={(e) =>
+                        updateField("medications", e.target.value)
+                      }
+                      rows={3}
+                      className="block w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary"
+                    />
+                  </div>
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700 mb-1">
+                      Notes
+                    </label>
+                    <textarea
+                      value={formData.notes}
+                      onChange={(e) => updateField("notes", e.target.value)}
+                      rows={3}
+                      className="block w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary"
+                    />
+                  </div>
+                </div>
+              ) : (
+                <div className="space-y-6">
+                  <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
+                    <InfoRow
+                      icon={<ShieldAlert className="h-5 w-5" />}
+                      label="Emergency Contact"
+                      value={patient.emergencyContact}
+                    />
+                    <InfoRow
+                      icon={<Phone className="h-5 w-5" />}
+                      label="Emergency Phone"
+                      value={patient.emergencyPhone}
+                    />
+                  </div>
+                  <div className="border-t border-gray-100 pt-4 space-y-4">
+                    <MedicalField
+                      icon={<AlertTriangle className="h-4 w-4 text-warning" />}
+                      label="Allergies"
+                      value={patient.allergies}
+                      emptyText="No known allergies"
+                    />
+                    <MedicalField
+                      icon={<Heart className="h-4 w-4 text-danger" />}
+                      label="Medical Conditions"
+                      value={patient.medicalConditions}
+                      emptyText="No conditions recorded"
+                    />
+                    <MedicalField
+                      icon={<Pill className="h-4 w-4 text-primary" />}
+                      label="Medications"
+                      value={patient.medications}
+                      emptyText="No medications recorded"
+                    />
+                    <MedicalField
+                      icon={<StickyNote className="h-4 w-4 text-gray-400" />}
+                      label="Notes"
+                      value={patient.notes}
+                      emptyText="No notes"
+                    />
+                  </div>
+                </div>
+              )}
+            </CardBody>
+          </Card>
+        </div>
+
+        {/* Sidebar - Quick Links & Meta */}
+        <div className="space-y-6">
+          {/* Quick Links */}
+          <Card>
+            <CardHeader>
+              <h2 className="text-lg font-semibold text-gray-900">
+                Quick Links
+              </h2>
+            </CardHeader>
+            <CardBody className="space-y-2">
+              <QuickLink
+                icon={<CalendarCheck className="h-5 w-5" />}
+                label="View Appointments"
+                href={`/appointments?patientId=${patient.id}`}
+                count={patient.appointments?.length}
+              />
+              <QuickLink
+                icon={<FlaskConical className="h-5 w-5" />}
+                label="View Lab Results"
+                href={`/lab-results?patientId=${patient.id}`}
+                count={patient.labResults?.length}
+              />
+              <QuickLink
+                icon={<ClipboardList className="h-5 w-5" />}
+                label="View Medical History"
+                href={`/medical-history?patientId=${patient.id}`}
+                count={patient.medicalHistories?.length}
+              />
+            </CardBody>
+          </Card>
+
+          {/* Record Info */}
+          <Card>
+            <CardHeader>
+              <h2 className="text-lg font-semibold text-gray-900">
+                Record Info
+              </h2>
+            </CardHeader>
+            <CardBody className="space-y-3">
+              <div>
+                <p className="text-xs text-gray-500 uppercase tracking-wider">
+                  Patient Number
+                </p>
+                <p className="text-sm font-mono font-medium text-gray-900">
+                  {patient.patientNumber}
+                </p>
+              </div>
+              <div>
+                <p className="text-xs text-gray-500 uppercase tracking-wider">
+                  Registered
+                </p>
+                <p className="text-sm text-gray-700">
+                  {new Date(patient.createdAt).toLocaleDateString("en-US", {
+                    year: "numeric",
+                    month: "long",
+                    day: "numeric",
+                  })}
+                </p>
+              </div>
+              <div>
+                <p className="text-xs text-gray-500 uppercase tracking-wider">
+                  Last Updated
+                </p>
+                <p className="text-sm text-gray-700">
+                  {new Date(patient.updatedAt).toLocaleDateString("en-US", {
+                    year: "numeric",
+                    month: "long",
+                    day: "numeric",
+                  })}
+                </p>
+              </div>
+              {patient.linkedUserId && (
+                <div>
+                  <Badge variant="success">Linked to User Account</Badge>
+                </div>
+              )}
+            </CardBody>
+          </Card>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ---------- Subcomponents ---------- */
+
+function InfoRow({
+  icon,
+  label,
+  value,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  value: string | null;
+}) {
+  return (
+    <div className="flex items-start gap-3">
+      <div className="text-gray-400 mt-0.5 shrink-0">{icon}</div>
+      <div>
+        <p className="text-xs text-gray-500 uppercase tracking-wider">
+          {label}
+        </p>
+        <p className="text-sm font-medium text-gray-900">
+          {value || "Not specified"}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function MedicalField({
+  icon,
+  label,
+  value,
+  emptyText,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  value: string | null;
+  emptyText: string;
+}) {
+  return (
+    <div>
+      <div className="flex items-center gap-2 mb-1">
+        {icon}
+        <span className="text-xs font-medium text-gray-500 uppercase tracking-wider">
+          {label}
+        </span>
+      </div>
+      <p
+        className={`text-sm leading-relaxed ${
+          value ? "text-gray-700" : "text-gray-400 italic"
+        }`}
+      >
+        {value || emptyText}
+      </p>
+    </div>
+  );
+}
+
+function QuickLink({
+  icon,
+  label,
+  href,
+  count,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  href: string;
+  count?: number;
+}) {
+  return (
+    <a
+      href={href}
+      className="flex items-center gap-3 p-3 rounded-lg hover:bg-gray-50 transition-colors group"
+    >
+      <div className="text-gray-400 group-hover:text-primary transition-colors">
+        {icon}
+      </div>
+      <span className="text-sm font-medium text-gray-700 group-hover:text-gray-900 flex-1">
+        {label}
+      </span>
+      {count !== undefined && count > 0 && (
+        <Badge variant="default">{count}</Badge>
+      )}
+    </a>
+  );
+}

--- a/src/app/(dashboard)/patients/new/page.tsx
+++ b/src/app/(dashboard)/patients/new/page.tsx
@@ -1,0 +1,382 @@
+"use client";
+
+import { useState } from "react";
+import {
+  ArrowLeft,
+  Save,
+  ChevronDown,
+  ChevronUp,
+  User,
+  Heart,
+} from "lucide-react";
+import { useOrganization } from "@/lib/hooks/use-organization";
+import { orgApiFetch, ApiError } from "@/lib/api";
+import Card, { CardBody, CardHeader } from "@/components/ui/Card";
+import Button from "@/components/ui/Button";
+import Input from "@/components/ui/Input";
+import Spinner from "@/components/ui/Spinner";
+
+interface PatientFormData {
+  firstName: string;
+  lastName: string;
+  dateOfBirth: string;
+  gender: string;
+  phone: string;
+  email: string;
+  address: string;
+  emergencyContact: string;
+  emergencyPhone: string;
+  allergies: string;
+  medicalConditions: string;
+  medications: string;
+  notes: string;
+}
+
+const initialFormData: PatientFormData = {
+  firstName: "",
+  lastName: "",
+  dateOfBirth: "",
+  gender: "",
+  phone: "",
+  email: "",
+  address: "",
+  emergencyContact: "",
+  emergencyPhone: "",
+  allergies: "",
+  medicalConditions: "",
+  medications: "",
+  notes: "",
+};
+
+export default function NewPatientPage() {
+  const { orgId, loading: orgLoading } = useOrganization();
+  const [formData, setFormData] = useState<PatientFormData>(initialFormData);
+  const [medicalExpanded, setMedicalExpanded] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
+
+  const updateField = (field: keyof PatientFormData, value: string) => {
+    setFormData((prev) => ({ ...prev, [field]: value }));
+    // Clear field-level error when user types
+    if (fieldErrors[field]) {
+      setFieldErrors((prev) => {
+        const next = { ...prev };
+        delete next[field];
+        return next;
+      });
+    }
+  };
+
+  const validate = (): boolean => {
+    const errors: Record<string, string> = {};
+    if (!formData.firstName.trim()) errors.firstName = "First name is required";
+    if (!formData.lastName.trim()) errors.lastName = "Last name is required";
+    if (!formData.dateOfBirth) errors.dateOfBirth = "Date of birth is required";
+    if (!formData.gender) errors.gender = "Gender is required";
+
+    if (formData.email && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(formData.email)) {
+      errors.email = "Invalid email address";
+    }
+
+    setFieldErrors(errors);
+    return Object.keys(errors).length === 0;
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!orgId || !validate()) return;
+
+    setSubmitting(true);
+    setError(null);
+
+    try {
+      // Build payload, omitting empty optional fields
+      const payload: Record<string, string> = {
+        firstName: formData.firstName.trim(),
+        lastName: formData.lastName.trim(),
+        dateOfBirth: formData.dateOfBirth,
+        gender: formData.gender,
+      };
+      if (formData.phone.trim()) payload.phone = formData.phone.trim();
+      if (formData.email.trim()) payload.email = formData.email.trim();
+      if (formData.address.trim()) payload.address = formData.address.trim();
+      if (formData.emergencyContact.trim())
+        payload.emergencyContact = formData.emergencyContact.trim();
+      if (formData.emergencyPhone.trim())
+        payload.emergencyPhone = formData.emergencyPhone.trim();
+      if (formData.allergies.trim())
+        payload.allergies = formData.allergies.trim();
+      if (formData.medicalConditions.trim())
+        payload.medicalConditions = formData.medicalConditions.trim();
+      if (formData.medications.trim())
+        payload.medications = formData.medications.trim();
+      if (formData.notes.trim()) payload.notes = formData.notes.trim();
+
+      const data = await orgApiFetch<{ patient: { id: string } }>(
+        "/patients",
+        orgId,
+        {
+          method: "POST",
+          body: JSON.stringify(payload),
+        }
+      );
+
+      window.location.href = `/patients/${data.patient.id}`;
+    } catch (err) {
+      if (err instanceof ApiError) {
+        setError(err.message);
+      } else {
+        setError("An unexpected error occurred. Please try again.");
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (orgLoading || !orgId) {
+    return (
+      <div className="flex justify-center py-16">
+        <Spinner size="lg" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-3xl mx-auto space-y-6">
+      {/* Header */}
+      <div className="flex items-center gap-3">
+        <button
+          onClick={() => (window.location.href = "/patients")}
+          className="p-2 rounded-lg hover:bg-gray-100 text-gray-500 transition-colors"
+        >
+          <ArrowLeft className="h-5 w-5" />
+        </button>
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">
+            Register New Patient
+          </h1>
+          <p className="text-sm text-gray-500 mt-0.5">
+            Fill in the patient details below
+          </p>
+        </div>
+      </div>
+
+      {/* Error Banner */}
+      {error && (
+        <div className="bg-danger-light border border-danger/20 rounded-xl px-4 py-3">
+          <p className="text-sm text-danger font-medium">{error}</p>
+        </div>
+      )}
+
+      <form onSubmit={handleSubmit}>
+        {/* Basic Information */}
+        <Card>
+          <CardHeader>
+            <div className="flex items-center gap-2">
+              <User className="h-5 w-5 text-primary" />
+              <h2 className="text-lg font-semibold text-gray-900">
+                Basic Information
+              </h2>
+            </div>
+          </CardHeader>
+          <CardBody className="space-y-4">
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <Input
+                label="First Name *"
+                placeholder="John"
+                value={formData.firstName}
+                onChange={(e) => updateField("firstName", e.target.value)}
+                error={fieldErrors.firstName}
+              />
+              <Input
+                label="Last Name *"
+                placeholder="Doe"
+                value={formData.lastName}
+                onChange={(e) => updateField("lastName", e.target.value)}
+                error={fieldErrors.lastName}
+              />
+            </div>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <Input
+                label="Date of Birth *"
+                type="date"
+                value={formData.dateOfBirth}
+                onChange={(e) => updateField("dateOfBirth", e.target.value)}
+                error={fieldErrors.dateOfBirth}
+              />
+              <div className="w-full">
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  Gender *
+                </label>
+                <select
+                  value={formData.gender}
+                  onChange={(e) => updateField("gender", e.target.value)}
+                  className={`block w-full rounded-lg border bg-white px-3 py-2 text-sm text-gray-900 transition-colors focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary ${
+                    fieldErrors.gender
+                      ? "border-danger focus:ring-danger/30 focus:border-danger"
+                      : "border-gray-300"
+                  }`}
+                >
+                  <option value="">Select gender</option>
+                  <option value="MALE">Male</option>
+                  <option value="FEMALE">Female</option>
+                  <option value="OTHER">Other</option>
+                </select>
+                {fieldErrors.gender && (
+                  <p className="mt-1 text-sm text-danger">
+                    {fieldErrors.gender}
+                  </p>
+                )}
+              </div>
+            </div>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <Input
+                label="Phone"
+                type="tel"
+                placeholder="+1 (555) 000-0000"
+                value={formData.phone}
+                onChange={(e) => updateField("phone", e.target.value)}
+              />
+              <Input
+                label="Email"
+                type="email"
+                placeholder="john.doe@email.com"
+                value={formData.email}
+                onChange={(e) => updateField("email", e.target.value)}
+                error={fieldErrors.email}
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                Address
+              </label>
+              <textarea
+                value={formData.address}
+                onChange={(e) => updateField("address", e.target.value)}
+                placeholder="Street address, city, state, zip code"
+                rows={2}
+                className="block w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary"
+              />
+            </div>
+          </CardBody>
+        </Card>
+
+        {/* Medical Information (Expandable) */}
+        <Card className="mt-6">
+          <button
+            type="button"
+            onClick={() => setMedicalExpanded(!medicalExpanded)}
+            className="w-full px-6 py-4 flex items-center justify-between hover:bg-gray-50 transition-colors rounded-xl"
+          >
+            <div className="flex items-center gap-2">
+              <Heart className="h-5 w-5 text-accent" />
+              <h2 className="text-lg font-semibold text-gray-900">
+                Medical Information
+              </h2>
+              <span className="text-xs text-gray-400 font-normal">
+                (Optional)
+              </span>
+            </div>
+            {medicalExpanded ? (
+              <ChevronUp className="h-5 w-5 text-gray-400" />
+            ) : (
+              <ChevronDown className="h-5 w-5 text-gray-400" />
+            )}
+          </button>
+          {medicalExpanded && (
+            <CardBody className="space-y-4 border-t border-gray-100">
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                <Input
+                  label="Emergency Contact"
+                  placeholder="Contact name"
+                  value={formData.emergencyContact}
+                  onChange={(e) =>
+                    updateField("emergencyContact", e.target.value)
+                  }
+                />
+                <Input
+                  label="Emergency Phone"
+                  type="tel"
+                  placeholder="+1 (555) 000-0000"
+                  value={formData.emergencyPhone}
+                  onChange={(e) =>
+                    updateField("emergencyPhone", e.target.value)
+                  }
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  Allergies
+                </label>
+                <textarea
+                  value={formData.allergies}
+                  onChange={(e) => updateField("allergies", e.target.value)}
+                  placeholder="List known allergies (e.g., Penicillin, Latex, Peanuts)"
+                  rows={2}
+                  className="block w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary"
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  Medical Conditions
+                </label>
+                <textarea
+                  value={formData.medicalConditions}
+                  onChange={(e) =>
+                    updateField("medicalConditions", e.target.value)
+                  }
+                  placeholder="List existing medical conditions (e.g., Hypertension, Diabetes Type 2)"
+                  rows={3}
+                  className="block w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary"
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  Current Medications
+                </label>
+                <textarea
+                  value={formData.medications}
+                  onChange={(e) => updateField("medications", e.target.value)}
+                  placeholder="List current medications and dosages"
+                  rows={3}
+                  className="block w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary"
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  Notes
+                </label>
+                <textarea
+                  value={formData.notes}
+                  onChange={(e) => updateField("notes", e.target.value)}
+                  placeholder="Additional notes or observations"
+                  rows={3}
+                  className="block w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary"
+                />
+              </div>
+            </CardBody>
+          )}
+        </Card>
+
+        {/* Actions */}
+        <div className="flex items-center justify-between mt-6">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => (window.location.href = "/patients")}
+          >
+            Cancel
+          </Button>
+          <Button
+            type="submit"
+            loading={submitting}
+            icon={<Save className="h-4 w-4" />}
+          >
+            Register Patient
+          </Button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/src/app/(dashboard)/patients/page.tsx
+++ b/src/app/(dashboard)/patients/page.tsx
@@ -1,0 +1,267 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import {
+  Search,
+  Plus,
+  ChevronLeft,
+  ChevronRight,
+  Users,
+} from "lucide-react";
+import { useOrganization } from "@/lib/hooks/use-organization";
+import { orgApiFetch } from "@/lib/api";
+import { useDebounce } from "@/lib/hooks/use-debounce";
+import Card, { CardBody } from "@/components/ui/Card";
+import Button from "@/components/ui/Button";
+import Input from "@/components/ui/Input";
+import Spinner from "@/components/ui/Spinner";
+import EmptyState from "@/components/ui/EmptyState";
+import Badge from "@/components/ui/Badge";
+
+interface Patient {
+  id: string;
+  organizationId: string;
+  patientNumber: string;
+  firstName: string;
+  lastName: string;
+  dateOfBirth: string;
+  gender: "MALE" | "FEMALE" | "OTHER";
+  phone: string | null;
+  email: string | null;
+  address: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface PatientsResponse {
+  patients: Patient[];
+  pagination: {
+    page: number;
+    limit: number;
+    total: number;
+    totalPages: number;
+  };
+}
+
+const ITEMS_PER_PAGE = 20;
+
+const GENDER_BADGE: Record<string, { label: string; variant: "primary" | "accent" | "default" }> = {
+  MALE: { label: "Male", variant: "primary" },
+  FEMALE: { label: "Female", variant: "accent" },
+  OTHER: { label: "Other", variant: "default" },
+};
+
+export default function PatientsPage() {
+  const { orgId, loading: orgLoading } = useOrganization();
+  const [patients, setPatients] = useState<Patient[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [currentPage, setCurrentPage] = useState(1);
+  const [totalPatients, setTotalPatients] = useState(0);
+  const [totalPages, setTotalPages] = useState(1);
+
+  const debouncedSearch = useDebounce(searchQuery, 300);
+
+  const fetchPatients = useCallback(async () => {
+    if (!orgId) return;
+    setLoading(true);
+    try {
+      const params = new URLSearchParams({
+        page: String(currentPage),
+        limit: String(ITEMS_PER_PAGE),
+      });
+      if (debouncedSearch) {
+        params.set("search", debouncedSearch);
+      }
+      const data = await orgApiFetch<PatientsResponse>(
+        `/patients?${params.toString()}`,
+        orgId
+      );
+      setPatients(data.patients);
+      setTotalPatients(data.pagination.total);
+      setTotalPages(data.pagination.totalPages);
+    } catch {
+      // silently handle
+    } finally {
+      setLoading(false);
+    }
+  }, [orgId, currentPage, debouncedSearch]);
+
+  useEffect(() => {
+    fetchPatients();
+  }, [fetchPatients]);
+
+  // Reset to page 1 when search changes
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [debouncedSearch]);
+
+  if (orgLoading || !orgId) {
+    return (
+      <div className="flex justify-center py-16">
+        <Spinner size="lg" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">Patients</h1>
+          <p className="text-sm text-gray-500 mt-1">
+            {totalPatients} patient{totalPatients !== 1 ? "s" : ""} registered
+          </p>
+        </div>
+        <Button
+          icon={<Plus className="h-4 w-4" />}
+          onClick={() => (window.location.href = "/patients/new")}
+        >
+          New Patient
+        </Button>
+      </div>
+
+      {/* Search Bar */}
+      <Card>
+        <CardBody>
+          <div className="flex-1 w-full sm:max-w-xs">
+            <Input
+              placeholder="Search by name, patient #, phone, or email..."
+              icon={<Search className="h-4 w-4" />}
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+            />
+          </div>
+        </CardBody>
+      </Card>
+
+      {/* Table */}
+      {loading ? (
+        <div className="flex justify-center py-12">
+          <Spinner size="lg" />
+        </div>
+      ) : patients.length === 0 ? (
+        <EmptyState
+          icon={<Users className="h-16 w-16" />}
+          title="No patients found"
+          description={
+            searchQuery
+              ? "Try adjusting your search criteria."
+              : "Get started by registering your first patient."
+          }
+          action={
+            !searchQuery ? (
+              <Button
+                icon={<Plus className="h-4 w-4" />}
+                onClick={() => (window.location.href = "/patients/new")}
+              >
+                New Patient
+              </Button>
+            ) : undefined
+          }
+        />
+      ) : (
+        <Card>
+          <div className="overflow-x-auto">
+            <table className="w-full">
+              <thead>
+                <tr className="border-b border-gray-100">
+                  <th className="text-left px-6 py-3 text-xs font-medium text-gray-500 uppercase tracking-wider">
+                    Patient #
+                  </th>
+                  <th className="text-left px-6 py-3 text-xs font-medium text-gray-500 uppercase tracking-wider">
+                    Name
+                  </th>
+                  <th className="text-left px-6 py-3 text-xs font-medium text-gray-500 uppercase tracking-wider hidden sm:table-cell">
+                    Gender
+                  </th>
+                  <th className="text-left px-6 py-3 text-xs font-medium text-gray-500 uppercase tracking-wider hidden md:table-cell">
+                    Date of Birth
+                  </th>
+                  <th className="text-left px-6 py-3 text-xs font-medium text-gray-500 uppercase tracking-wider hidden lg:table-cell">
+                    Phone
+                  </th>
+                  <th className="text-left px-6 py-3 text-xs font-medium text-gray-500 uppercase tracking-wider hidden lg:table-cell">
+                    Email
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-50">
+                {patients.map((patient) => (
+                  <tr
+                    key={patient.id}
+                    className="hover:bg-gray-50 cursor-pointer transition-colors"
+                    onClick={() =>
+                      (window.location.href = `/patients/${patient.id}`)
+                    }
+                  >
+                    <td className="px-6 py-4">
+                      <span className="text-sm font-mono text-primary font-medium">
+                        {patient.patientNumber}
+                      </span>
+                    </td>
+                    <td className="px-6 py-4">
+                      <p className="text-sm font-medium text-gray-900">
+                        {patient.firstName} {patient.lastName}
+                      </p>
+                    </td>
+                    <td className="px-6 py-4 hidden sm:table-cell">
+                      <Badge
+                        variant={
+                          GENDER_BADGE[patient.gender]?.variant || "default"
+                        }
+                      >
+                        {GENDER_BADGE[patient.gender]?.label || patient.gender}
+                      </Badge>
+                    </td>
+                    <td className="px-6 py-4 text-sm text-gray-500 hidden md:table-cell">
+                      {new Date(patient.dateOfBirth).toLocaleDateString()}
+                    </td>
+                    <td className="px-6 py-4 text-sm text-gray-500 hidden lg:table-cell">
+                      {patient.phone || "\u2014"}
+                    </td>
+                    <td className="px-6 py-4 text-sm text-gray-500 hidden lg:table-cell">
+                      {patient.email || "\u2014"}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </Card>
+      )}
+
+      {/* Pagination */}
+      {totalPages > 1 && (
+        <div className="flex items-center justify-between">
+          <p className="text-sm text-gray-500">
+            Showing {(currentPage - 1) * ITEMS_PER_PAGE + 1} to{" "}
+            {Math.min(currentPage * ITEMS_PER_PAGE, totalPatients)} of{" "}
+            {totalPatients}
+          </p>
+          <div className="flex items-center gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={currentPage === 1}
+              onClick={() => setCurrentPage(currentPage - 1)}
+              icon={<ChevronLeft className="h-4 w-4" />}
+            >
+              Previous
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={currentPage === totalPages}
+              onClick={() => setCurrentPage(currentPage + 1)}
+            >
+              Next
+              <ChevronRight className="h-4 w-4" />
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/(dashboard)/settings/create-org/page.tsx
+++ b/src/app/(dashboard)/settings/create-org/page.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import { useState } from "react";
+import {
+  ArrowLeft,
+  Building2,
+  Rocket,
+} from "lucide-react";
+import { useOrganization } from "@/lib/hooks/use-organization";
+import { apiFetch } from "@/lib/api";
+import Card, { CardBody, CardHeader, CardFooter } from "@/components/ui/Card";
+import Button from "@/components/ui/Button";
+import Input from "@/components/ui/Input";
+
+function slugify(text: string): string {
+  return text
+    .toLowerCase()
+    .trim()
+    .replace(/[^\w\s-]/g, "")
+    .replace(/[\s_]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "");
+}
+
+export default function CreateOrgPage() {
+  const { refetch } = useOrganization();
+
+  const [name, setName] = useState("");
+  const [slug, setSlug] = useState("");
+  const [slugEdited, setSlugEdited] = useState(false);
+  const [creating, setCreating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleNameChange = (value: string) => {
+    setName(value);
+    if (!slugEdited) {
+      setSlug(slugify(value));
+    }
+  };
+
+  const handleSlugChange = (value: string) => {
+    setSlugEdited(true);
+    setSlug(slugify(value));
+  };
+
+  const handleCreate = async () => {
+    if (!name || !slug) return;
+    setCreating(true);
+    setError(null);
+
+    try {
+      await apiFetch("/organizations", {
+        method: "POST",
+        body: JSON.stringify({ name, slug }),
+      });
+      refetch();
+      window.location.href = "/settings";
+    } catch (err) {
+      if (err instanceof Error) {
+        setError(err.message);
+      } else {
+        setError("Failed to create organization. Please try again.");
+      }
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  return (
+    <div className="max-w-lg mx-auto space-y-6">
+      {/* Header */}
+      <div className="flex items-center gap-3">
+        <button
+          onClick={() => (window.location.href = "/settings")}
+          className="p-2 rounded-lg hover:bg-gray-100 text-gray-500 transition-colors"
+        >
+          <ArrowLeft className="h-5 w-5" />
+        </button>
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">
+            Create Organization
+          </h1>
+          <p className="text-sm text-gray-500 mt-0.5">
+            Set up a new organization for your team
+          </p>
+        </div>
+      </div>
+
+      {/* Error Banner */}
+      {error && (
+        <div className="bg-danger-light border border-danger/20 text-danger rounded-lg px-4 py-3 text-sm">
+          {error}
+        </div>
+      )}
+
+      <Card>
+        <CardHeader>
+          <div className="flex items-center gap-3">
+            <div className="rounded-lg bg-primary-light p-2.5">
+              <Building2 className="h-5 w-5 text-primary" />
+            </div>
+            <div>
+              <h2 className="text-lg font-semibold text-gray-900">
+                Organization Details
+              </h2>
+              <p className="text-sm text-gray-500">
+                Choose a name and URL slug for your organization.
+              </p>
+            </div>
+          </div>
+        </CardHeader>
+        <CardBody className="space-y-4">
+          <Input
+            label="Organization Name"
+            placeholder="e.g., Sunrise Eye Clinic"
+            value={name}
+            onChange={(e) => handleNameChange(e.target.value)}
+          />
+          <div>
+            <Input
+              label="URL Slug"
+              placeholder="e.g., sunrise-eye-clinic"
+              value={slug}
+              onChange={(e) => handleSlugChange(e.target.value)}
+            />
+            <p className="mt-1 text-xs text-gray-400">
+              This will be used in URLs and must be unique. Only lowercase letters, numbers, and hyphens.
+            </p>
+          </div>
+        </CardBody>
+        <CardFooter className="flex items-center justify-between">
+          <Button
+            variant="outline"
+            onClick={() => (window.location.href = "/settings")}
+          >
+            Cancel
+          </Button>
+          <Button
+            icon={<Rocket className="h-4 w-4" />}
+            loading={creating}
+            disabled={!name || !slug}
+            onClick={handleCreate}
+          >
+            Create Organization
+          </Button>
+        </CardFooter>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/(dashboard)/settings/page.tsx
+++ b/src/app/(dashboard)/settings/page.tsx
@@ -1,0 +1,720 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { useRouter } from "next/navigation";
+import {
+  Settings,
+  Users,
+  ToggleLeft,
+  ToggleRight,
+  ScrollText,
+  Plus,
+  Trash2,
+  Shield,
+  Building2,
+  UserPlus,
+  ChevronRight,
+} from "lucide-react";
+import { useOrganization } from "@/lib/hooks/use-organization";
+import { orgApiFetch } from "@/lib/api";
+import Card, { CardBody, CardHeader, CardFooter } from "@/components/ui/Card";
+import Button from "@/components/ui/Button";
+import Input from "@/components/ui/Input";
+import Modal from "@/components/ui/Modal";
+import Badge from "@/components/ui/Badge";
+import Spinner from "@/components/ui/Spinner";
+import EmptyState from "@/components/ui/EmptyState";
+
+type OrgRole = "OWNER" | "ADMIN" | "DOCTOR" | "NURSE" | "RECEPTIONIST";
+
+interface FeatureFlag {
+  featureKey: string;
+  enabled: boolean;
+}
+
+interface Member {
+  id: string;
+  email: string;
+  name: string | null;
+  role: OrgRole;
+  joinedAt: string;
+}
+
+interface AuditLogEntry {
+  id: string;
+  action: string;
+  userId: string;
+  userName: string | null;
+  details: string | null;
+  createdAt: string;
+}
+
+type SettingsTab = "info" | "features" | "members" | "audit";
+
+const FEATURE_DESCRIPTIONS: Record<string, string> = {
+  eye_consultation: "Eye consultation and exam module",
+  appointments: "Appointment scheduling",
+  predictive_maintenance: "Equipment predictive maintenance",
+  ai_interpretation: "AI-powered lab result interpretation",
+  family_management: "Family member management",
+  report_sharing: "Medical record sharing",
+  follow_ups: "Follow-up tracking",
+  provider_portal: "Healthcare provider portal",
+  lab_results: "Lab results management",
+  medical_history: "Medical history tracking",
+};
+
+const FEATURE_DISPLAY_NAMES: Record<string, string> = {
+  eye_consultation: "Eye Consultation",
+  appointments: "Appointments",
+  predictive_maintenance: "Predictive Maintenance",
+  ai_interpretation: "AI Interpretation",
+  family_management: "Family Management",
+  report_sharing: "Report Sharing",
+  follow_ups: "Follow-ups",
+  provider_portal: "Provider Portal",
+  lab_results: "Lab Results",
+  medical_history: "Medical History",
+};
+
+const ROLE_BADGE_VARIANTS: Record<OrgRole, "primary" | "accent" | "success" | "warning" | "default"> = {
+  OWNER: "primary",
+  ADMIN: "accent",
+  DOCTOR: "success",
+  NURSE: "warning",
+  RECEPTIONIST: "default",
+};
+
+const ALL_ROLES: OrgRole[] = ["OWNER", "ADMIN", "DOCTOR", "NURSE", "RECEPTIONIST"];
+
+export default function SettingsPage() {
+  const router = useRouter();
+  const { orgId, activeOrg, organizations, loading: orgLoading } = useOrganization();
+  const [activeTab, setActiveTab] = useState<SettingsTab>("info");
+
+  // Feature flags state
+  const [features, setFeatures] = useState<FeatureFlag[]>([]);
+  const [featuresLoading, setFeaturesLoading] = useState(false);
+  const [featureTogglingKey, setFeatureTogglingKey] = useState<string | null>(null);
+
+  // Members state
+  const [members, setMembers] = useState<Member[]>([]);
+  const [membersLoading, setMembersLoading] = useState(false);
+  const [addMemberOpen, setAddMemberOpen] = useState(false);
+  const [newMemberEmail, setNewMemberEmail] = useState("");
+  const [newMemberRole, setNewMemberRole] = useState<OrgRole>("DOCTOR");
+  const [addingMember, setAddingMember] = useState(false);
+  const [removingMemberId, setRemovingMemberId] = useState<string | null>(null);
+  const [editingMember, setEditingMember] = useState<{ id: string; role: OrgRole } | null>(null);
+
+  // Audit logs state
+  const [auditLogs, setAuditLogs] = useState<AuditLogEntry[]>([]);
+  const [auditLoading, setAuditLoading] = useState(false);
+
+  // Error state
+  const [error, setError] = useState<string | null>(null);
+
+  const isPrivileged = activeOrg?.role === "OWNER" || activeOrg?.role === "ADMIN";
+
+  const fetchFeatures = useCallback(async () => {
+    if (!orgId) return;
+    setFeaturesLoading(true);
+    try {
+      const data = await orgApiFetch<{ features: FeatureFlag[] }>(
+        `/organizations/${orgId}/features`,
+        orgId
+      );
+      setFeatures(data.features);
+    } catch {
+      setError("Failed to load feature flags.");
+    } finally {
+      setFeaturesLoading(false);
+    }
+  }, [orgId]);
+
+  const fetchMembers = useCallback(async () => {
+    if (!orgId) return;
+    setMembersLoading(true);
+    try {
+      const data = await orgApiFetch<{ members: Member[] }>(
+        `/organizations/${orgId}/members`,
+        orgId
+      );
+      setMembers(data.members);
+    } catch {
+      setError("Failed to load members.");
+    } finally {
+      setMembersLoading(false);
+    }
+  }, [orgId]);
+
+  const fetchAuditLogs = useCallback(async () => {
+    if (!orgId) return;
+    setAuditLoading(true);
+    try {
+      const data = await orgApiFetch<{ logs: AuditLogEntry[] }>(
+        `/organizations/${orgId}/audit-logs`,
+        orgId
+      );
+      setAuditLogs(data.logs);
+    } catch {
+      setError("Failed to load audit logs.");
+    } finally {
+      setAuditLoading(false);
+    }
+  }, [orgId]);
+
+  useEffect(() => {
+    if (!orgId) return;
+    if (activeTab === "features") fetchFeatures();
+    if (activeTab === "members") fetchMembers();
+    if (activeTab === "audit") fetchAuditLogs();
+  }, [activeTab, orgId, fetchFeatures, fetchMembers, fetchAuditLogs]);
+
+  const handleToggleFeature = async (featureKey: string, enabled: boolean) => {
+    if (!orgId || !isPrivileged) return;
+    setFeatureTogglingKey(featureKey);
+    setError(null);
+    try {
+      await orgApiFetch(`/organizations/${orgId}/features`, orgId, {
+        method: "PUT",
+        body: JSON.stringify({ featureKey, enabled: !enabled }),
+      });
+      setFeatures((prev) =>
+        prev.map((f) =>
+          f.featureKey === featureKey ? { ...f, enabled: !enabled } : f
+        )
+      );
+    } catch {
+      setError("Failed to toggle feature.");
+    } finally {
+      setFeatureTogglingKey(null);
+    }
+  };
+
+  const handleAddMember = async () => {
+    if (!orgId || !newMemberEmail) return;
+    setAddingMember(true);
+    setError(null);
+    try {
+      await orgApiFetch(`/organizations/${orgId}/members`, orgId, {
+        method: "POST",
+        body: JSON.stringify({ email: newMemberEmail, role: newMemberRole }),
+      });
+      setAddMemberOpen(false);
+      setNewMemberEmail("");
+      setNewMemberRole("DOCTOR");
+      fetchMembers();
+    } catch {
+      setError("Failed to add member. Check the email address and try again.");
+    } finally {
+      setAddingMember(false);
+    }
+  };
+
+  const handleRemoveMember = async (memberId: string) => {
+    if (!orgId || !isPrivileged) return;
+    setRemovingMemberId(memberId);
+    setError(null);
+    try {
+      await orgApiFetch(`/organizations/${orgId}/members/${memberId}`, orgId, {
+        method: "DELETE",
+      });
+      setMembers((prev) => prev.filter((m) => m.id !== memberId));
+    } catch {
+      setError("Failed to remove member.");
+    } finally {
+      setRemovingMemberId(null);
+    }
+  };
+
+  const handleUpdateRole = async (memberId: string, role: OrgRole) => {
+    if (!orgId || !isPrivileged) return;
+    setError(null);
+    try {
+      await orgApiFetch(`/organizations/${orgId}/members/${memberId}`, orgId, {
+        method: "PUT",
+        body: JSON.stringify({ role }),
+      });
+      setMembers((prev) =>
+        prev.map((m) => (m.id === memberId ? { ...m, role } : m))
+      );
+      setEditingMember(null);
+    } catch {
+      setError("Failed to update role.");
+    }
+  };
+
+  // No org state
+  if (orgLoading) {
+    return (
+      <div className="flex justify-center py-16">
+        <Spinner size="lg" />
+      </div>
+    );
+  }
+
+  if (!orgId || organizations.length === 0) {
+    return (
+      <div className="max-w-lg mx-auto space-y-6">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">Settings</h1>
+          <p className="text-sm text-gray-500 mt-1">
+            Create an organization to get started.
+          </p>
+        </div>
+        <EmptyState
+          icon={<Building2 className="h-16 w-16" />}
+          title="No Organization"
+          description="You are not part of any organization yet. Create one to start managing your team and features."
+          action={
+            <Button
+              icon={<Plus className="h-4 w-4" />}
+              onClick={() => router.push("/settings/create-org")}
+            >
+              Create Organization
+            </Button>
+          }
+        />
+      </div>
+    );
+  }
+
+  const tabs: { id: SettingsTab; label: string; icon: React.ReactNode }[] = [
+    { id: "info", label: "Organization", icon: <Building2 className="h-4 w-4" /> },
+    { id: "features", label: "Features", icon: <ToggleLeft className="h-4 w-4" /> },
+    { id: "members", label: "Members", icon: <Users className="h-4 w-4" /> },
+    { id: "audit", label: "Audit Log", icon: <ScrollText className="h-4 w-4" /> },
+  ];
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">Settings</h1>
+          <p className="text-sm text-gray-500 mt-1">
+            Manage your organization, features, and team.
+          </p>
+        </div>
+        {isPrivileged && (
+          <Badge variant="primary">
+            <Shield className="h-3 w-3 mr-1" />
+            {activeOrg?.role}
+          </Badge>
+        )}
+      </div>
+
+      {/* Error Banner */}
+      {error && (
+        <div className="bg-danger-light border border-danger/20 text-danger rounded-lg px-4 py-3 text-sm">
+          {error}
+          <button
+            className="ml-2 underline text-xs"
+            onClick={() => setError(null)}
+          >
+            Dismiss
+          </button>
+        </div>
+      )}
+
+      {/* Tab Navigation */}
+      <div className="flex gap-1 bg-gray-100 rounded-lg p-1">
+        {tabs.map((tab) => (
+          <button
+            key={tab.id}
+            onClick={() => setActiveTab(tab.id)}
+            className={`flex items-center gap-2 px-4 py-2 rounded-md text-sm font-medium transition-colors flex-1 justify-center ${
+              activeTab === tab.id
+                ? "bg-white text-gray-900 shadow-sm"
+                : "text-gray-500 hover:text-gray-700"
+            }`}
+          >
+            {tab.icon}
+            <span className="hidden sm:inline">{tab.label}</span>
+          </button>
+        ))}
+      </div>
+
+      {/* Tab Content */}
+      {activeTab === "info" && (
+        <Card>
+          <CardHeader>
+            <h2 className="text-lg font-semibold text-gray-900">
+              Organization Information
+            </h2>
+          </CardHeader>
+          <CardBody className="space-y-4">
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <div>
+                <label className="block text-sm font-medium text-gray-500 mb-1">
+                  Name
+                </label>
+                <p className="text-sm text-gray-900 font-medium">
+                  {activeOrg?.name}
+                </p>
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-500 mb-1">
+                  Slug
+                </label>
+                <p className="text-sm text-gray-900 font-mono">
+                  {activeOrg?.slug}
+                </p>
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-500 mb-1">
+                  Your Role
+                </label>
+                <Badge variant={ROLE_BADGE_VARIANTS[activeOrg?.role as OrgRole] || "default"}>
+                  {activeOrg?.role}
+                </Badge>
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-500 mb-1">
+                  Members
+                </label>
+                <p className="text-sm text-gray-900">{activeOrg?.memberCount}</p>
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-500 mb-1">
+                  Created
+                </label>
+                <p className="text-sm text-gray-900">
+                  {activeOrg?.createdAt
+                    ? new Date(activeOrg.createdAt).toLocaleDateString("en-US", {
+                        year: "numeric",
+                        month: "long",
+                        day: "numeric",
+                      })
+                    : "N/A"}
+                </p>
+              </div>
+            </div>
+          </CardBody>
+          <CardFooter className="flex justify-end">
+            <Button
+              variant="outline"
+              size="sm"
+              icon={<Plus className="h-4 w-4" />}
+              onClick={() => router.push("/settings/create-org")}
+            >
+              Create New Organization
+            </Button>
+          </CardFooter>
+        </Card>
+      )}
+
+      {activeTab === "features" && (
+        <Card>
+          <CardHeader className="flex items-center justify-between">
+            <div>
+              <h2 className="text-lg font-semibold text-gray-900">
+                Feature Flags
+              </h2>
+              <p className="text-sm text-gray-500 mt-0.5">
+                Enable or disable features for your organization.
+              </p>
+            </div>
+          </CardHeader>
+          <CardBody>
+            {featuresLoading ? (
+              <div className="flex justify-center py-8">
+                <Spinner size="lg" />
+              </div>
+            ) : features.length === 0 ? (
+              <p className="text-sm text-gray-500 text-center py-8">
+                No feature flags available.
+              </p>
+            ) : (
+              <div className="divide-y divide-gray-100">
+                {features.map((feature) => (
+                  <div
+                    key={feature.featureKey}
+                    className="flex items-center justify-between py-4 first:pt-0 last:pb-0"
+                  >
+                    <div className="min-w-0 flex-1">
+                      <p className="text-sm font-medium text-gray-900">
+                        {FEATURE_DISPLAY_NAMES[feature.featureKey] || feature.featureKey}
+                      </p>
+                      <p className="text-xs text-gray-500 mt-0.5">
+                        {FEATURE_DESCRIPTIONS[feature.featureKey] || "No description available."}
+                      </p>
+                    </div>
+                    <button
+                      onClick={() =>
+                        handleToggleFeature(feature.featureKey, feature.enabled)
+                      }
+                      disabled={!isPrivileged || featureTogglingKey === feature.featureKey}
+                      className={`ml-4 shrink-0 transition-colors ${
+                        !isPrivileged ? "opacity-50 cursor-not-allowed" : "cursor-pointer"
+                      }`}
+                      title={
+                        isPrivileged
+                          ? `Toggle ${feature.featureKey}`
+                          : "Only OWNER or ADMIN can toggle features"
+                      }
+                    >
+                      {featureTogglingKey === feature.featureKey ? (
+                        <Spinner size="sm" />
+                      ) : feature.enabled ? (
+                        <ToggleRight className="h-7 w-7 text-success" />
+                      ) : (
+                        <ToggleLeft className="h-7 w-7 text-gray-300" />
+                      )}
+                    </button>
+                  </div>
+                ))}
+              </div>
+            )}
+          </CardBody>
+        </Card>
+      )}
+
+      {activeTab === "members" && (
+        <div className="space-y-4">
+          <Card>
+            <CardHeader className="flex items-center justify-between">
+              <div>
+                <h2 className="text-lg font-semibold text-gray-900">
+                  Team Members
+                </h2>
+                <p className="text-sm text-gray-500 mt-0.5">
+                  {members.length} member{members.length !== 1 ? "s" : ""} in this organization.
+                </p>
+              </div>
+              {isPrivileged && (
+                <Button
+                  size="sm"
+                  icon={<UserPlus className="h-4 w-4" />}
+                  onClick={() => setAddMemberOpen(true)}
+                >
+                  Add Member
+                </Button>
+              )}
+            </CardHeader>
+            <CardBody>
+              {membersLoading ? (
+                <div className="flex justify-center py-8">
+                  <Spinner size="lg" />
+                </div>
+              ) : members.length === 0 ? (
+                <p className="text-sm text-gray-500 text-center py-8">
+                  No members found.
+                </p>
+              ) : (
+                <div className="divide-y divide-gray-100">
+                  {members.map((member) => (
+                    <div
+                      key={member.id}
+                      className="flex items-center justify-between py-3 first:pt-0 last:pb-0"
+                    >
+                      <div className="flex items-center gap-3 min-w-0">
+                        <div className="h-9 w-9 rounded-full bg-primary-light flex items-center justify-center shrink-0">
+                          <span className="text-sm font-medium text-primary">
+                            {(member.name || member.email)[0].toUpperCase()}
+                          </span>
+                        </div>
+                        <div className="min-w-0">
+                          <p className="text-sm font-medium text-gray-900 truncate">
+                            {member.name || member.email}
+                          </p>
+                          <p className="text-xs text-gray-500 truncate">
+                            {member.email}
+                          </p>
+                        </div>
+                      </div>
+                      <div className="flex items-center gap-2 ml-4 shrink-0">
+                        {editingMember?.id === member.id ? (
+                          <select
+                            value={editingMember.role}
+                            onChange={(e) =>
+                              setEditingMember({
+                                ...editingMember,
+                                role: e.target.value as OrgRole,
+                              })
+                            }
+                            className="text-xs border border-gray-300 rounded-lg px-2 py-1 bg-white focus:outline-none focus:ring-2 focus:ring-primary/30"
+                          >
+                            {ALL_ROLES.map((role) => (
+                              <option key={role} value={role}>
+                                {role}
+                              </option>
+                            ))}
+                          </select>
+                        ) : (
+                          <Badge variant={ROLE_BADGE_VARIANTS[member.role] || "default"}>
+                            {member.role}
+                          </Badge>
+                        )}
+                        {isPrivileged && member.role !== "OWNER" && (
+                          <div className="flex items-center gap-1">
+                            {editingMember?.id === member.id ? (
+                              <>
+                                <Button
+                                  size="sm"
+                                  variant="primary"
+                                  onClick={() =>
+                                    handleUpdateRole(member.id, editingMember.role)
+                                  }
+                                >
+                                  Save
+                                </Button>
+                                <Button
+                                  size="sm"
+                                  variant="ghost"
+                                  onClick={() => setEditingMember(null)}
+                                >
+                                  Cancel
+                                </Button>
+                              </>
+                            ) : (
+                              <>
+                                <Button
+                                  size="sm"
+                                  variant="ghost"
+                                  onClick={() =>
+                                    setEditingMember({
+                                      id: member.id,
+                                      role: member.role,
+                                    })
+                                  }
+                                >
+                                  Edit
+                                </Button>
+                                <Button
+                                  size="sm"
+                                  variant="danger"
+                                  loading={removingMemberId === member.id}
+                                  icon={<Trash2 className="h-3 w-3" />}
+                                  onClick={() => handleRemoveMember(member.id)}
+                                >
+                                  Remove
+                                </Button>
+                              </>
+                            )}
+                          </div>
+                        )}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </CardBody>
+          </Card>
+
+          {/* Add Member Modal */}
+          <Modal
+            open={addMemberOpen}
+            onClose={() => setAddMemberOpen(false)}
+            title="Add Team Member"
+          >
+            <div className="space-y-4">
+              <Input
+                label="Email Address"
+                type="email"
+                placeholder="colleague@example.com"
+                value={newMemberEmail}
+                onChange={(e) => setNewMemberEmail(e.target.value)}
+              />
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  Role
+                </label>
+                <select
+                  value={newMemberRole}
+                  onChange={(e) => setNewMemberRole(e.target.value as OrgRole)}
+                  className="block w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary"
+                >
+                  {ALL_ROLES.filter((r) => r !== "OWNER").map((role) => (
+                    <option key={role} value={role}>
+                      {role}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div className="flex justify-end gap-2 pt-2">
+                <Button variant="outline" onClick={() => setAddMemberOpen(false)}>
+                  Cancel
+                </Button>
+                <Button
+                  loading={addingMember}
+                  disabled={!newMemberEmail}
+                  onClick={handleAddMember}
+                >
+                  Add Member
+                </Button>
+              </div>
+            </div>
+          </Modal>
+        </div>
+      )}
+
+      {activeTab === "audit" && (
+        <Card>
+          <CardHeader>
+            <h2 className="text-lg font-semibold text-gray-900">Audit Log</h2>
+            <p className="text-sm text-gray-500 mt-0.5">
+              Recent activity in your organization.
+            </p>
+          </CardHeader>
+          <CardBody>
+            {auditLoading ? (
+              <div className="flex justify-center py-8">
+                <Spinner size="lg" />
+              </div>
+            ) : auditLogs.length === 0 ? (
+              <p className="text-sm text-gray-500 text-center py-8">
+                No audit logs available yet.
+              </p>
+            ) : (
+              <div className="overflow-x-auto">
+                <table className="w-full">
+                  <thead>
+                    <tr className="border-b border-gray-100">
+                      <th className="text-left px-4 py-3 text-xs font-medium text-gray-500 uppercase tracking-wider">
+                        Action
+                      </th>
+                      <th className="text-left px-4 py-3 text-xs font-medium text-gray-500 uppercase tracking-wider">
+                        User
+                      </th>
+                      <th className="text-left px-4 py-3 text-xs font-medium text-gray-500 uppercase tracking-wider hidden md:table-cell">
+                        Details
+                      </th>
+                      <th className="text-left px-4 py-3 text-xs font-medium text-gray-500 uppercase tracking-wider">
+                        Time
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-gray-50">
+                    {auditLogs.map((log) => (
+                      <tr key={log.id}>
+                        <td className="px-4 py-3">
+                          <Badge variant="default">{log.action}</Badge>
+                        </td>
+                        <td className="px-4 py-3 text-sm text-gray-700">
+                          {log.userName || log.userId}
+                        </td>
+                        <td className="px-4 py-3 text-sm text-gray-500 hidden md:table-cell max-w-xs truncate">
+                          {log.details || "--"}
+                        </td>
+                        <td className="px-4 py-3 text-sm text-gray-500 whitespace-nowrap">
+                          {new Date(log.createdAt).toLocaleString("en-US", {
+                            month: "short",
+                            day: "numeric",
+                            hour: "2-digit",
+                            minute: "2-digit",
+                          })}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </CardBody>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/src/components/Providers.tsx
+++ b/src/components/Providers.tsx
@@ -1,7 +1,12 @@
 "use client";
 
 import { SessionProvider } from "next-auth/react";
+import OrgProvider from "@/components/providers/OrgProvider";
 
 export default function Providers({ children }: { children: React.ReactNode }) {
-  return <SessionProvider>{children}</SessionProvider>;
+  return (
+    <SessionProvider>
+      <OrgProvider>{children}</OrgProvider>
+    </SessionProvider>
+  );
 }

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -9,14 +9,24 @@ import {
   Users,
   UserCircle,
   Activity,
+  UserPlus,
+  Calendar,
+  TestTube,
+  Eye,
+  ClipboardList,
+  Settings,
 } from "lucide-react";
 
 const navItems = [
   { href: "/dashboard", label: "Dashboard", icon: LayoutDashboard },
+  { href: "/patients", label: "Patients", icon: UserPlus },
+  { href: "/appointments", label: "Appointments", icon: Calendar },
+  { href: "/lab-results", label: "Lab Results", icon: TestTube },
+  { href: "/eye-consultations", label: "Eye Consult", icon: Eye },
   { href: "/records", label: "Records", icon: FolderOpen },
   { href: "/care", label: "Care", icon: HeartPulse },
   { href: "/family", label: "Family", icon: Users },
-  { href: "/profile", label: "Profile", icon: UserCircle },
+  { href: "/settings", label: "Settings", icon: Settings },
 ];
 
 export default function Sidebar() {
@@ -27,7 +37,7 @@ export default function Sidebar() {
       <div className="p-4">
         <div className="flex items-center gap-2 px-3 py-2 mb-6">
           <Activity className="h-7 w-7 text-primary" />
-          <span className="text-xl font-bold text-gray-900">HealthApp</span>
+          <span className="text-xl font-bold text-gray-900">NdụMed</span>
         </div>
 
         <nav className="space-y-1">

--- a/src/components/providers/OrgProvider.tsx
+++ b/src/components/providers/OrgProvider.tsx
@@ -1,0 +1,8 @@
+"use client";
+
+import { OrgContext, useOrganizationProvider } from "@/lib/hooks/use-organization";
+
+export default function OrgProvider({ children }: { children: React.ReactNode }) {
+  const orgValue = useOrganizationProvider();
+  return <OrgContext.Provider value={orgValue}>{children}</OrgContext.Provider>;
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -24,6 +24,21 @@ export async function apiFetch<T>(
   return res.json();
 }
 
+/** apiFetch with organization context header */
+export async function orgApiFetch<T>(
+  path: string,
+  orgId: string,
+  options?: RequestInit,
+): Promise<T> {
+  return apiFetch<T>(path, {
+    ...options,
+    headers: {
+      "x-organization-id": orgId,
+      ...options?.headers,
+    },
+  });
+}
+
 export const RECORD_TYPE_DISPLAY: Record<string, string> = {
   MRI: "MRI",
   XRAY: "X-Ray",

--- a/src/lib/hooks/use-organization.ts
+++ b/src/lib/hooks/use-organization.ts
@@ -1,0 +1,75 @@
+"use client";
+
+import { useState, useEffect, useCallback, createContext, useContext } from "react";
+import { useSession } from "next-auth/react";
+import { apiFetch } from "@/lib/api";
+
+export interface Organization {
+  id: string;
+  name: string;
+  slug: string;
+  role: string;
+  memberCount: number;
+  createdAt: string;
+}
+
+interface OrgContextValue {
+  organizations: Organization[];
+  activeOrg: Organization | null;
+  orgId: string | null;
+  loading: boolean;
+  setActiveOrg: (org: Organization) => void;
+  refetch: () => void;
+}
+
+const OrgContext = createContext<OrgContextValue>({
+  organizations: [],
+  activeOrg: null,
+  orgId: null,
+  loading: true,
+  setActiveOrg: () => {},
+  refetch: () => {},
+});
+
+export function useOrganization() {
+  return useContext(OrgContext);
+}
+
+export { OrgContext };
+
+export function useOrganizationProvider(): OrgContextValue {
+  const { data: session } = useSession();
+  const [organizations, setOrganizations] = useState<Organization[]>([]);
+  const [activeOrg, setActiveOrg] = useState<Organization | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const fetchOrgs = useCallback(() => {
+    if (!session?.user?.id) return;
+    setLoading(true);
+    apiFetch<{ organizations: Organization[] }>("/organizations")
+      .then((data) => {
+        setOrganizations(data.organizations);
+        if (data.organizations.length > 0 && !activeOrg) {
+          // Default to the org matching session or first org
+          const sessionOrgId = session.user.activeOrganizationId;
+          const match = data.organizations.find((o) => o.id === sessionOrgId);
+          setActiveOrg(match || data.organizations[0]);
+        }
+      })
+      .catch(() => {})
+      .finally(() => setLoading(false));
+  }, [session?.user?.id, session?.user?.activeOrganizationId, activeOrg]);
+
+  useEffect(() => {
+    fetchOrgs();
+  }, [fetchOrgs]);
+
+  return {
+    organizations,
+    activeOrg,
+    orgId: activeOrg?.id || null,
+    loading,
+    setActiveOrg,
+    refetch: fetchOrgs,
+  };
+}


### PR DESCRIPTION
## Summary

- **14 new pages** covering all Phase 1-3 backend features with full UI
- **Organization context provider** — all org-scoped pages now pass `x-organization-id` header automatically
- **Updated sidebar** with Patients, Appointments, Lab Results, Eye Consultations, Settings navigation

## New Pages

### Patients (3 pages)
- **List** — search, pagination, table with patient #, name, gender, DOB, phone, email
- **Create** — form with basic info + expandable medical info section
- **Detail** — view/edit mode toggle, quick links to appointments/lab results/history

### Appointments (3 pages)
- **List** — status filter tabs (All/Scheduled/Completed/Cancelled/No Show), color-coded badges
- **Create** — patient selector, date/time, doctor, reason
- **Detail** — status management buttons (Complete, Cancel, No Show), editable notes

### Lab Results (3 pages)
- **List** — risk level badges, AI interpretation status indicator
- **Create** — patient selector, test info, reference range
- **Detail** — full AI interpretation UI with interpret button, confidence bar, recommendations list, interpretation history

### Eye Consultations (2 pages)
- **List** — table with modal detail view showing bilateral exam data
- **Create** — bilateral exam form (12 fields × RE/LE), diagnosis, treatment plan

### Organization Settings (2 pages)
- **Settings hub** — tabbed interface with Feature Flags, Members, Audit Log sections
- **Create Organization** — name, slug, redirect to settings

### Medical History (1 page)
- Patient selector, current summary card, timeline with expandable entries, add entry form

## Infrastructure Changes
- `orgApiFetch()` utility for org-scoped API calls
- `useOrganization()` hook + `OrgProvider` context
- Updated `Providers.tsx` to wrap with OrgProvider
- Updated Sidebar with new nav items + NdụMed branding

## Verification
- 173 tests passing
- Zero type errors
- Build clean (all 14 routes visible)