### PR TITLE
fix: critical UX gaps — email, route protection, consent, org switcher

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "lucide-react": "^0.563.0",
         "next": "16.1.6",
         "next-auth": "^4.24.13",
+        "nodemailer": "^7.0.13",
         "openai": "^6.25.0",
         "otpauth": "^9.5.0",
         "pg": "^8.18.0",
@@ -31,6 +32,7 @@
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
         "@types/node": "^20",
+        "@types/nodemailer": "^7.0.11",
         "@types/pg": "^8.16.0",
         "@types/qrcode": "^1.5.6",
         "@types/react": "^19",
@@ -2838,6 +2840,16 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/nodemailer": {
+      "version": "7.0.11",
+      "resolved": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-7.0.11.tgz",
+      "integrity": "sha512-E+U4RzR2dKrx+u3N4DlsmLaDC6mMZOM/TPROxA0UAPiTgI0y4CEFBmZE+coGWTjakDriRsXG368lNk1u9Q0a2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/pg": {
@@ -7100,6 +7112,15 @@
       "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/nodemailer": {
+      "version": "7.0.13",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.13.tgz",
+      "integrity": "sha512-PNDFSJdP+KFgdsG3ZzMXCgquO7I6McjY2vlqILjtJd0hy8wEvtugS9xKRF2NWlPNGxvLCXlTNIae4serI7dinw==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/nypm": {
       "version": "0.6.5",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "lucide-react": "^0.563.0",
     "next": "16.1.6",
     "next-auth": "^4.24.13",
+    "nodemailer": "^7.0.13",
     "openai": "^6.25.0",
     "otpauth": "^9.5.0",
     "pg": "^8.18.0",
@@ -34,6 +35,7 @@
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
+    "@types/nodemailer": "^7.0.11",
     "@types/pg": "^8.16.0",
     "@types/qrcode": "^1.5.6",
     "@types/react": "^19",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -137,17 +137,21 @@ model SharedRecord {
 }
 
 model FamilyMember {
-  id           String   @id @default(cuid())
-  userId       String
-  memberUserId String
-  relationship String
-  consentGiven Boolean  @default(false)
-  createdAt    DateTime @default(now())
+  id                String    @id @default(cuid())
+  userId            String
+  memberUserId      String
+  relationship      String
+  consentGiven      Boolean   @default(false)
+  consentToken      String?   @unique
+  consentTokenExpiry DateTime?
+  consentRespondedAt DateTime?
+  createdAt         DateTime  @default(now())
 
   user   User @relation("UserFamilyMembers", fields: [userId], references: [id], onDelete: Cascade)
   member User @relation("MemberOfFamily", fields: [memberUserId], references: [id], onDelete: Cascade)
 
   @@unique([userId, memberUserId])
+  @@index([consentToken])
 }
 
 model FollowUp {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -65,6 +65,9 @@ model User {
   mfaSecret       String?   // Encrypted TOTP secret
   mfaBackupCodes  String?   // Encrypted JSON array of hashed backup codes
   mfaVerifiedAt   DateTime? // When MFA was first verified/activated
+  emailVerified         Boolean   @default(false)
+  emailVerificationToken String?  @unique
+  emailVerificationExpiry DateTime?
   createdAt       DateTime  @default(now())
   updatedAt       DateTime  @updatedAt
 

--- a/src/app/(dashboard)/appointments/page.tsx
+++ b/src/app/(dashboard)/appointments/page.tsx
@@ -13,6 +13,7 @@ import {
   CalendarDays,
 } from "lucide-react";
 import { useOrganization } from "@/lib/hooks/use-organization";
+import { useRequireProviderRole } from "@/lib/hooks/use-require-role";
 import { orgApiFetch } from "@/lib/api";
 import Card, { CardBody } from "@/components/ui/Card";
 import Button from "@/components/ui/Button";
@@ -73,6 +74,7 @@ const statusFilters: { value: string; label: string }[] = [
 const ITEMS_PER_PAGE = 20;
 
 export default function AppointmentsPage() {
+  const { allowed, loading: roleLoading } = useRequireProviderRole();
   const { orgId, loading: orgLoading } = useOrganization();
   const router = useRouter();
 
@@ -143,7 +145,7 @@ export default function AppointmentsPage() {
     }
   }, [viewMode, fetchCalendarAppointments]);
 
-  if (orgLoading || !orgId) {
+  if (roleLoading || !allowed || orgLoading || !orgId) {
     return (
       <div className="flex justify-center py-16">
         <Spinner size="lg" />

--- a/src/app/(dashboard)/equipment/page.tsx
+++ b/src/app/(dashboard)/equipment/page.tsx
@@ -11,6 +11,7 @@ import {
   AlertTriangle,
 } from "lucide-react";
 import { useOrganization } from "@/lib/hooks/use-organization";
+import { useRequireProviderRole } from "@/lib/hooks/use-require-role";
 import { orgApiFetch } from "@/lib/api";
 import { useDebounce } from "@/lib/hooks/use-debounce";
 import Card, { CardBody } from "@/components/ui/Card";
@@ -66,6 +67,7 @@ const TYPE_LABELS: Record<string, string> = {
 };
 
 export default function EquipmentPage() {
+  const { allowed, loading: roleLoading } = useRequireProviderRole();
   const { orgId, loading: orgLoading } = useOrganization();
   const [equipment, setEquipment] = useState<Equipment[]>([]);
   const [loading, setLoading] = useState(true);
@@ -112,7 +114,7 @@ export default function EquipmentPage() {
     setCurrentPage(1);
   }, [debouncedSearch, typeFilter, statusFilter]);
 
-  if (orgLoading || !orgId) {
+  if (roleLoading || !allowed || orgLoading || !orgId) {
     return (
       <div className="flex justify-center py-16">
         <Spinner size="lg" />

--- a/src/app/(dashboard)/eye-consultations/page.tsx
+++ b/src/app/(dashboard)/eye-consultations/page.tsx
@@ -12,6 +12,7 @@ import {
   X,
 } from "lucide-react";
 import { useOrganization } from "@/lib/hooks/use-organization";
+import { useRequireProviderRole } from "@/lib/hooks/use-require-role";
 import { orgApiFetch } from "@/lib/api";
 import Card, { CardBody, CardHeader } from "@/components/ui/Card";
 import Button from "@/components/ui/Button";
@@ -79,6 +80,7 @@ const EXAM_FIELDS = [
 ] as const;
 
 export default function EyeConsultationsPage() {
+  const { allowed, loading: roleLoading } = useRequireProviderRole();
   const { orgId, loading: orgLoading } = useOrganization();
 
   const [consultations, setConsultations] = useState<Consultation[]>([]);
@@ -115,7 +117,7 @@ export default function EyeConsultationsPage() {
     fetchConsultations();
   }, [fetchConsultations]);
 
-  if (orgLoading || !orgId) {
+  if (roleLoading || !allowed || orgLoading || !orgId) {
     return (
       <div className="flex justify-center py-16">
         <Spinner size="lg" />

--- a/src/app/(dashboard)/family/consent/page.tsx
+++ b/src/app/(dashboard)/family/consent/page.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import { useEffect, useState, Suspense } from "react";
+import { useSearchParams } from "next/navigation";
+import { CheckCircle, XCircle, Loader2, AlertTriangle } from "lucide-react";
+import Link from "next/link";
+
+function ConsentContent() {
+  const searchParams = useSearchParams();
+  const token = searchParams.get("token");
+  const action = searchParams.get("action");
+
+  const [status, setStatus] = useState<"loading" | "success" | "error">("loading");
+  const [message, setMessage] = useState("");
+  const [consentResult, setConsentResult] = useState<"accepted" | "rejected" | null>(null);
+
+  useEffect(() => {
+    if (!token || !action) {
+      setStatus("error");
+      setMessage("Invalid consent link. Missing token or action.");
+      return;
+    }
+
+    fetch(`/api/family/consent?token=${token}&action=${action}`)
+      .then(async (res) => {
+        const data = await res.json();
+        if (res.ok) {
+          setStatus("success");
+          setMessage(data.message);
+          setConsentResult(data.status);
+        } else {
+          setStatus("error");
+          setMessage(data.error || "Something went wrong.");
+        }
+      })
+      .catch(() => {
+        setStatus("error");
+        setMessage("Network error. Please try again.");
+      });
+  }, [token, action]);
+
+  return (
+    <div className="min-h-[60vh] flex items-center justify-center">
+      <div className="max-w-md w-full mx-auto px-4">
+        <div className="bg-white rounded-xl border border-gray-200 p-8 text-center">
+          {status === "loading" && (
+            <>
+              <Loader2 className="w-12 h-12 animate-spin text-primary mx-auto mb-4" />
+              <h2 className="text-lg font-semibold text-gray-900 mb-2">
+                Processing your response...
+              </h2>
+            </>
+          )}
+
+          {status === "success" && consentResult === "accepted" && (
+            <>
+              <CheckCircle className="w-12 h-12 text-green-500 mx-auto mb-4" />
+              <h2 className="text-lg font-semibold text-gray-900 mb-2">
+                Consent Accepted
+              </h2>
+              <p className="text-gray-600 mb-6">{message}</p>
+              <Link
+                href="/family"
+                className="inline-block px-6 py-2.5 bg-primary text-white rounded-lg text-sm font-medium hover:bg-primary/90"
+              >
+                Go to Family
+              </Link>
+            </>
+          )}
+
+          {status === "success" && consentResult === "rejected" && (
+            <>
+              <XCircle className="w-12 h-12 text-red-500 mx-auto mb-4" />
+              <h2 className="text-lg font-semibold text-gray-900 mb-2">
+                Consent Declined
+              </h2>
+              <p className="text-gray-600 mb-6">{message}</p>
+              <Link
+                href="/family"
+                className="inline-block px-6 py-2.5 bg-gray-100 text-gray-700 rounded-lg text-sm font-medium hover:bg-gray-200"
+              >
+                Go to Family
+              </Link>
+            </>
+          )}
+
+          {status === "error" && (
+            <>
+              <AlertTriangle className="w-12 h-12 text-yellow-500 mx-auto mb-4" />
+              <h2 className="text-lg font-semibold text-gray-900 mb-2">
+                Something Went Wrong
+              </h2>
+              <p className="text-gray-600 mb-6">{message}</p>
+              <Link
+                href="/family"
+                className="inline-block px-6 py-2.5 bg-primary text-white rounded-lg text-sm font-medium hover:bg-primary/90"
+              >
+                Go to Family
+              </Link>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function FamilyConsentPage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="min-h-[60vh] flex items-center justify-center">
+          <Loader2 className="w-8 h-8 animate-spin text-primary" />
+        </div>
+      }
+    >
+      <ConsentContent />
+    </Suspense>
+  );
+}

--- a/src/app/(dashboard)/lab-results/page.tsx
+++ b/src/app/(dashboard)/lab-results/page.tsx
@@ -12,6 +12,7 @@ import {
   Calendar,
 } from "lucide-react";
 import { useOrganization } from "@/lib/hooks/use-organization";
+import { useRequireProviderRole } from "@/lib/hooks/use-require-role";
 import { orgApiFetch } from "@/lib/api";
 import Card, { CardBody } from "@/components/ui/Card";
 import Button from "@/components/ui/Button";
@@ -68,6 +69,7 @@ const RISK_LEVEL_BADGE_MAP: Record<string, { label: string; variant: BadgeVarian
 const ITEMS_PER_PAGE = 20;
 
 export default function LabResultsPage() {
+  const { allowed, loading: roleLoading } = useRequireProviderRole();
   const { orgId, loading: orgLoading } = useOrganization();
   const router = useRouter();
 
@@ -104,7 +106,7 @@ export default function LabResultsPage() {
     fetchResults();
   }, [fetchResults]);
 
-  if (orgLoading || !orgId) {
+  if (roleLoading || !allowed || orgLoading || !orgId) {
     return (
       <div className="flex justify-center py-16">
         <Spinner size="lg" />

--- a/src/app/(dashboard)/medical-history/page.tsx
+++ b/src/app/(dashboard)/medical-history/page.tsx
@@ -15,6 +15,7 @@ import {
   Save,
 } from "lucide-react";
 import { useOrganization } from "@/lib/hooks/use-organization";
+import { useRequireProviderRole } from "@/lib/hooks/use-require-role";
 import { orgApiFetch } from "@/lib/api";
 import Card, { CardBody, CardHeader, CardFooter } from "@/components/ui/Card";
 import Button from "@/components/ui/Button";
@@ -54,6 +55,7 @@ export default function MedicalHistoryPage() {
 }
 
 function MedicalHistoryContent() {
+  const { allowed, loading: roleLoading } = useRequireProviderRole();
   const { orgId, loading: orgLoading } = useOrganization();
   const searchParams = useSearchParams();
   const urlPatientId = searchParams.get("patientId");
@@ -190,7 +192,7 @@ function MedicalHistoryContent() {
     });
   };
 
-  if (orgLoading || !orgId) {
+  if (roleLoading || !allowed || orgLoading || !orgId) {
     return (
       <div className="flex justify-center py-16">
         <Spinner size="lg" />

--- a/src/app/(dashboard)/patients/page.tsx
+++ b/src/app/(dashboard)/patients/page.tsx
@@ -9,6 +9,7 @@ import {
   Users,
 } from "lucide-react";
 import { useOrganization } from "@/lib/hooks/use-organization";
+import { useRequireProviderRole } from "@/lib/hooks/use-require-role";
 import { orgApiFetch } from "@/lib/api";
 import { useDebounce } from "@/lib/hooks/use-debounce";
 import Card, { CardBody } from "@/components/ui/Card";
@@ -52,6 +53,7 @@ const GENDER_BADGE: Record<string, { label: string; variant: "primary" | "accent
 };
 
 export default function PatientsPage() {
+  const { allowed, loading: roleLoading } = useRequireProviderRole();
   const { orgId, loading: orgLoading } = useOrganization();
   const [patients, setPatients] = useState<Patient[]>([]);
   const [loading, setLoading] = useState(true);
@@ -96,7 +98,7 @@ export default function PatientsPage() {
     setCurrentPage(1);
   }, [debouncedSearch]);
 
-  if (orgLoading || !orgId) {
+  if (roleLoading || !allowed || orgLoading || !orgId) {
     return (
       <div className="flex justify-center py-16">
         <Spinner size="lg" />

--- a/src/app/api/auth/send-verification/route.ts
+++ b/src/app/api/auth/send-verification/route.ts
@@ -1,0 +1,67 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { sendVerificationEmail } from "@/lib/email";
+import { checkRateLimit } from "@/lib/rate-limit";
+import { getClientIp } from "@/lib/audit";
+import crypto from "crypto";
+
+// POST /api/auth/send-verification — resend/send verification email
+export async function POST(request: NextRequest) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const ip = getClientIp(request);
+  const rateCheck = checkRateLimit(`send-verification:${session.user.id}`, {
+    maxAttempts: 3,
+    windowMs: 15 * 60 * 1000, // 3 per 15 min
+  });
+  if (!rateCheck.allowed) {
+    return NextResponse.json(
+      { error: "Too many requests. Please wait before requesting another verification email." },
+      { status: 429 }
+    );
+  }
+
+  const user = await prisma.user.findUnique({
+    where: { id: session.user.id },
+    select: { id: true, email: true, name: true, emailVerified: true },
+  });
+
+  if (!user) {
+    return NextResponse.json({ error: "User not found." }, { status: 404 });
+  }
+
+  if (user.emailVerified) {
+    return NextResponse.json({ message: "Email is already verified." });
+  }
+
+  const token = crypto.randomBytes(32).toString("hex");
+  const expiry = new Date(Date.now() + 24 * 60 * 60 * 1000); // 24 hours
+
+  await prisma.user.update({
+    where: { id: user.id },
+    data: {
+      emailVerificationToken: token,
+      emailVerificationExpiry: expiry,
+    },
+  });
+
+  // Send email (non-blocking — degrade gracefully if SMTP not configured)
+  try {
+    await sendVerificationEmail(user.email, token, user.name);
+  } catch (err) {
+    console.warn("Failed to send verification email:", err);
+    return NextResponse.json(
+      { error: "Failed to send verification email. Please check your SMTP configuration." },
+      { status: 503 }
+    );
+  }
+
+  void ip; // used for future audit logging
+
+  return NextResponse.json({ message: "Verification email sent. Check your inbox." });
+}

--- a/src/app/api/auth/switch-org/route.ts
+++ b/src/app/api/auth/switch-org/route.ts
@@ -1,0 +1,91 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { logAudit, getClientIp } from "@/lib/audit";
+
+// PATCH /api/auth/switch-org — update the active organization for the current session
+// The client must call router.refresh() after this to pick up the new session data.
+export async function PATCH(request: NextRequest) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const body = await request.json();
+  const { organizationId } = body;
+
+  if (!organizationId) {
+    return NextResponse.json({ error: "organizationId is required." }, { status: 400 });
+  }
+
+  // Verify the user actually belongs to this org
+  const membership = await prisma.organizationMember.findFirst({
+    where: {
+      userId: session.user.id,
+      organizationId,
+    },
+    include: {
+      organization: { select: { id: true, name: true, slug: true } },
+    },
+  });
+
+  if (!membership) {
+    return NextResponse.json(
+      { error: "You are not a member of this organization." },
+      { status: 403 }
+    );
+  }
+
+  await logAudit({
+    userId: session.user.id,
+    action: "ORG_SWITCHED",
+    entityType: "organization",
+    entityId: organizationId,
+    details: `Switched to organization: ${membership.organization.name}`,
+    ipAddress: getClientIp(request),
+  });
+
+  // We can't update the JWT directly from an API route — the session is updated
+  // on the next JWT refresh via the jwt callback in authOptions.
+  // We store the desired org ID in a cookie that the jwt callback reads.
+  const response = NextResponse.json({
+    message: `Switched to ${membership.organization.name}`,
+    organization: membership.organization,
+  });
+
+  // Set a short-lived cookie the jwt callback can read to update activeOrganizationId
+  response.cookies.set("preferred-org", organizationId, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax",
+    maxAge: 60, // 60 seconds — just long enough for the next JWT refresh
+    path: "/",
+  });
+
+  return response;
+}
+
+// GET /api/auth/switch-org — list orgs the current user belongs to
+export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const memberships = await prisma.organizationMember.findMany({
+    where: { userId: session.user.id },
+    include: {
+      organization: { select: { id: true, name: true, slug: true } },
+    },
+    orderBy: { createdAt: "asc" },
+  });
+
+  return NextResponse.json({
+    organizations: memberships.map((m) => ({
+      ...m.organization,
+      role: m.role,
+      isActive: m.organizationId === session.user.activeOrganizationId,
+    })),
+  });
+}

--- a/src/app/api/auth/verify-email/route.ts
+++ b/src/app/api/auth/verify-email/route.ts
@@ -1,0 +1,58 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { logAudit, getClientIp } from "@/lib/audit";
+
+// GET /api/auth/verify-email?token=xxx
+export async function GET(request: NextRequest) {
+  const token = request.nextUrl.searchParams.get("token");
+
+  if (!token) {
+    return NextResponse.json({ error: "Verification token is required." }, { status: 400 });
+  }
+
+  const user = await prisma.user.findUnique({
+    where: { emailVerificationToken: token },
+    select: {
+      id: true,
+      email: true,
+      name: true,
+      emailVerified: true,
+      emailVerificationExpiry: true,
+    },
+  });
+
+  if (!user) {
+    return NextResponse.json({ error: "Invalid or expired verification link." }, { status: 404 });
+  }
+
+  if (user.emailVerified) {
+    return NextResponse.json({ message: "Email already verified.", alreadyVerified: true });
+  }
+
+  if (user.emailVerificationExpiry && user.emailVerificationExpiry < new Date()) {
+    return NextResponse.json(
+      { error: "This verification link has expired. Please request a new one." },
+      { status: 410 }
+    );
+  }
+
+  await prisma.user.update({
+    where: { id: user.id },
+    data: {
+      emailVerified: true,
+      emailVerificationToken: null,
+      emailVerificationExpiry: null,
+    },
+  });
+
+  await logAudit({
+    userId: user.id,
+    action: "EMAIL_VERIFIED",
+    entityType: "user",
+    entityId: user.id,
+    details: `Email verified: ${user.email}`,
+    ipAddress: getClientIp(request),
+  });
+
+  return NextResponse.json({ message: "Email verified successfully.", email: user.email });
+}

--- a/src/app/api/family/consent/route.ts
+++ b/src/app/api/family/consent/route.ts
@@ -1,0 +1,136 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+
+// GET /api/family/consent?token=xxx&action=accept|reject
+// Processes consent token — requires authenticated user who is the family member
+export async function GET(request: NextRequest) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    // Redirect to login with return URL
+    const returnUrl = request.nextUrl.pathname + request.nextUrl.search;
+    return NextResponse.redirect(
+      new URL(`/login?callbackUrl=${encodeURIComponent(returnUrl)}`, request.url)
+    );
+  }
+
+  const token = request.nextUrl.searchParams.get("token");
+  const action = request.nextUrl.searchParams.get("action");
+
+  if (!token || !action || !["accept", "reject"].includes(action)) {
+    return NextResponse.json(
+      { error: "Invalid request. Token and action (accept/reject) are required." },
+      { status: 400 }
+    );
+  }
+
+  const familyMember = await prisma.familyMember.findUnique({
+    where: { consentToken: token },
+    include: {
+      user: { select: { name: true, email: true } },
+      member: { select: { id: true, name: true, email: true } },
+    },
+  });
+
+  if (!familyMember) {
+    return NextResponse.json(
+      { error: "Invalid or expired consent token." },
+      { status: 404 }
+    );
+  }
+
+  // Verify the logged-in user is the family member being asked for consent
+  if (familyMember.memberUserId !== session.user.id) {
+    return NextResponse.json(
+      { error: "This consent request is not for your account." },
+      { status: 403 }
+    );
+  }
+
+  // Check token expiry
+  if (familyMember.consentTokenExpiry && familyMember.consentTokenExpiry < new Date()) {
+    return NextResponse.json(
+      { error: "This consent link has expired. Ask the requester to send a new invitation." },
+      { status: 410 }
+    );
+  }
+
+  // Already responded
+  if (familyMember.consentRespondedAt) {
+    return NextResponse.json({
+      message: `You have already ${familyMember.consentGiven ? "accepted" : "declined"} this request.`,
+      status: familyMember.consentGiven ? "accepted" : "rejected",
+    });
+  }
+
+  // Process the consent
+  const isAccepted = action === "accept";
+
+  await prisma.familyMember.update({
+    where: { consentToken: token },
+    data: {
+      consentGiven: isAccepted,
+      consentRespondedAt: new Date(),
+      consentToken: null, // Invalidate token after use
+      consentTokenExpiry: null,
+    },
+  });
+
+  return NextResponse.json({
+    message: isAccepted
+      ? `You have accepted ${familyMember.user.name || "the request"}. You can now view shared medical records.`
+      : `You have declined ${familyMember.user.name || "the request"}. No records will be shared.`,
+    status: isAccepted ? "accepted" : "rejected",
+  });
+}
+
+// POST /api/family/consent — for the family member to accept/reject from the UI
+export async function POST(request: NextRequest) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const body = await request.json();
+  const { familyMemberId, action } = body;
+
+  if (!familyMemberId || !action || !["accept", "reject"].includes(action)) {
+    return NextResponse.json(
+      { error: "familyMemberId and action (accept/reject) are required." },
+      { status: 400 }
+    );
+  }
+
+  // Find the family member record where the current user IS the member
+  const familyMember = await prisma.familyMember.findFirst({
+    where: {
+      id: familyMemberId,
+      memberUserId: session.user.id,
+    },
+  });
+
+  if (!familyMember) {
+    return NextResponse.json(
+      { error: "Family connection not found." },
+      { status: 404 }
+    );
+  }
+
+  const isAccepted = action === "accept";
+
+  await prisma.familyMember.update({
+    where: { id: familyMemberId },
+    data: {
+      consentGiven: isAccepted,
+      consentRespondedAt: new Date(),
+      consentToken: null,
+      consentTokenExpiry: null,
+    },
+  });
+
+  return NextResponse.json({
+    message: isAccepted ? "Consent granted." : "Consent declined.",
+    consentGiven: isAccepted,
+  });
+}

--- a/src/app/verify-email/page.tsx
+++ b/src/app/verify-email/page.tsx
@@ -1,0 +1,151 @@
+"use client";
+
+import { useEffect, useState, Suspense } from "react";
+import { useSearchParams, useRouter } from "next/navigation";
+import { CheckCircle, XCircle, Loader2, AlertTriangle, Mail } from "lucide-react";
+import Link from "next/link";
+
+function VerifyEmailContent() {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const token = searchParams.get("token");
+
+  const [status, setStatus] = useState<"loading" | "success" | "error" | "no-token">("loading");
+  const [message, setMessage] = useState("");
+  const [resending, setResending] = useState(false);
+  const [resent, setResent] = useState(false);
+
+  useEffect(() => {
+    if (!token) {
+      setStatus("no-token");
+      return;
+    }
+
+    fetch(`/api/auth/verify-email?token=${encodeURIComponent(token)}`)
+      .then(async (res) => {
+        const data = await res.json();
+        if (res.ok) {
+          setStatus("success");
+          setMessage(data.message);
+          // Redirect to dashboard after 3 seconds
+          setTimeout(() => router.push("/dashboard"), 3000);
+        } else {
+          setStatus("error");
+          setMessage(data.error || "Verification failed.");
+        }
+      })
+      .catch(() => {
+        setStatus("error");
+        setMessage("Network error. Please try again.");
+      });
+  }, [token, router]);
+
+  async function handleResend() {
+    setResending(true);
+    try {
+      const res = await fetch("/api/auth/send-verification", { method: "POST" });
+      const data = await res.json();
+      if (res.ok) {
+        setResent(true);
+      } else {
+        setMessage(data.error || "Failed to resend.");
+      }
+    } catch {
+      setMessage("Network error. Please try again.");
+    } finally {
+      setResending(false);
+    }
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50 px-4">
+      <div className="max-w-md w-full">
+        <div className="bg-white rounded-xl border border-gray-200 p-8 text-center shadow-sm">
+          {status === "loading" && (
+            <>
+              <Loader2 className="w-12 h-12 animate-spin text-blue-500 mx-auto mb-4" />
+              <h2 className="text-lg font-semibold text-gray-900 mb-2">Verifying your email...</h2>
+              <p className="text-gray-500 text-sm">Please wait a moment.</p>
+            </>
+          )}
+
+          {status === "success" && (
+            <>
+              <CheckCircle className="w-12 h-12 text-green-500 mx-auto mb-4" />
+              <h2 className="text-lg font-semibold text-gray-900 mb-2">Email Verified!</h2>
+              <p className="text-gray-600 mb-6">{message}</p>
+              <p className="text-gray-400 text-sm mb-4">Redirecting to dashboard...</p>
+              <Link
+                href="/dashboard"
+                className="inline-block px-6 py-2.5 bg-blue-600 text-white rounded-lg text-sm font-medium hover:bg-blue-700"
+              >
+                Go to Dashboard
+              </Link>
+            </>
+          )}
+
+          {status === "error" && (
+            <>
+              <AlertTriangle className="w-12 h-12 text-yellow-500 mx-auto mb-4" />
+              <h2 className="text-lg font-semibold text-gray-900 mb-2">Verification Failed</h2>
+              <p className="text-gray-600 mb-6">{message}</p>
+              {resent ? (
+                <p className="text-green-600 text-sm font-medium">
+                  New verification email sent! Check your inbox.
+                </p>
+              ) : (
+                <button
+                  onClick={handleResend}
+                  disabled={resending}
+                  className="inline-flex items-center gap-2 px-6 py-2.5 bg-blue-600 text-white rounded-lg text-sm font-medium hover:bg-blue-700 disabled:opacity-50"
+                >
+                  {resending ? (
+                    <Loader2 className="w-4 h-4 animate-spin" />
+                  ) : (
+                    <Mail className="w-4 h-4" />
+                  )}
+                  Resend Verification Email
+                </button>
+              )}
+              <div className="mt-4">
+                <Link href="/dashboard" className="text-sm text-gray-500 hover:text-gray-700">
+                  Go to Dashboard
+                </Link>
+              </div>
+            </>
+          )}
+
+          {status === "no-token" && (
+            <>
+              <XCircle className="w-12 h-12 text-red-500 mx-auto mb-4" />
+              <h2 className="text-lg font-semibold text-gray-900 mb-2">Invalid Link</h2>
+              <p className="text-gray-600 mb-6">
+                This verification link is invalid. Check your email for the correct link.
+              </p>
+              <Link
+                href="/dashboard"
+                className="inline-block px-6 py-2.5 bg-gray-100 text-gray-700 rounded-lg text-sm font-medium hover:bg-gray-200"
+              >
+                Go to Dashboard
+              </Link>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function VerifyEmailPage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="min-h-screen flex items-center justify-center">
+          <Loader2 className="w-8 h-8 animate-spin text-blue-500" />
+        </div>
+      }
+    >
+      <VerifyEmailContent />
+    </Suspense>
+  );
+}

--- a/src/lib/audit.ts
+++ b/src/lib/audit.ts
@@ -48,7 +48,9 @@ type AuditAction =
   | "PREDICT_EQUIPMENT_FAILURE"
   | "ACKNOWLEDGE_ALERT"
   | "RESOLVE_ALERT"
-  | "DISMISS_ALERT";
+  | "DISMISS_ALERT"
+  | "EMAIL_VERIFIED"
+  | "ORG_SWITCHED";
 
 interface AuditParams {
   userId?: string;

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -1,0 +1,95 @@
+import nodemailer from "nodemailer";
+
+const transporter = nodemailer.createTransport({
+  host: process.env.SMTP_HOST || "smtp.gmail.com",
+  port: Number(process.env.SMTP_PORT) || 587,
+  secure: false,
+  auth: {
+    user: process.env.SMTP_USER,
+    pass: process.env.SMTP_PASSWORD,
+  },
+});
+
+const FROM_ADDRESS =
+  process.env.EMAIL_FROM || process.env.SMTP_USER || "noreply@ndumed.com";
+const APP_NAME = "NdụMed";
+
+function getBaseUrl(): string {
+  return process.env.NEXTAUTH_URL || "http://localhost:3000";
+}
+
+export async function sendFamilyConsentEmail(
+  to: string,
+  memberName: string | null | undefined,
+  requesterName: string | null | undefined,
+  consentToken?: string
+): Promise<void> {
+  const appUrl = getBaseUrl();
+  const greeting = memberName ? `Hi ${memberName}` : "Hi";
+  const sender = requesterName || "Someone";
+
+  const acceptUrl = consentToken
+    ? `${appUrl}/family/consent?token=${consentToken}&action=accept`
+    : `${appUrl}/family`;
+  const rejectUrl = consentToken
+    ? `${appUrl}/family/consent?token=${consentToken}&action=reject`
+    : `${appUrl}/family`;
+
+  await transporter.sendMail({
+    from: `"${APP_NAME}" <${FROM_ADDRESS}>`,
+    to,
+    subject: `${sender} wants to share medical records with you on ${APP_NAME}`,
+    html: `
+      <div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; max-width: 600px; margin: 0 auto; padding: 20px;">
+        <h2 style="color: #1a1a1a;">${APP_NAME}</h2>
+        <p>${greeting},</p>
+        <p><strong>${sender}</strong> has added you as a family member on ${APP_NAME} and wants to share their medical records with you.</p>
+        <p>Please review this request:</p>
+        <div style="text-align: center; margin: 30px 0;">
+          <a href="${acceptUrl}" style="display: inline-block; background-color: #16a34a; color: white; padding: 12px 24px; border-radius: 8px; text-decoration: none; font-weight: 600; margin-right: 12px;">
+            Accept
+          </a>
+          <a href="${rejectUrl}" style="display: inline-block; background-color: #dc2626; color: white; padding: 12px 24px; border-radius: 8px; text-decoration: none; font-weight: 600;">
+            Decline
+          </a>
+        </div>
+        <p style="color: #666; font-size: 14px;">This invitation expires in 7 days.</p>
+        <p style="color: #999; font-size: 12px;">Don't have an account? Register at <a href="${appUrl}">${appUrl}</a> first, then click Accept above.</p>
+      </div>
+    `,
+    text: `${greeting},\n\n${sender} wants to share medical records with you on ${APP_NAME}.\n\nAccept: ${acceptUrl}\nDecline: ${rejectUrl}\n\nThis invitation expires in 7 days.`,
+  });
+}
+
+export async function sendVerificationEmail(
+  to: string,
+  token: string,
+  name?: string | null
+): Promise<void> {
+  const verifyUrl = `${getBaseUrl()}/verify-email?token=${token}`;
+  const greeting = name ? `Hi ${name}` : "Hi";
+
+  await transporter.sendMail({
+    from: `"${APP_NAME}" <${FROM_ADDRESS}>`,
+    to,
+    subject: `Verify your ${APP_NAME} email`,
+    html: `
+      <div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; max-width: 600px; margin: 0 auto; padding: 20px;">
+        <h2 style="color: #1a1a1a;">${APP_NAME}</h2>
+        <p>${greeting},</p>
+        <p>Thanks for creating your ${APP_NAME} account. Please verify your email address by clicking the button below:</p>
+        <div style="text-align: center; margin: 30px 0;">
+          <a href="${verifyUrl}" style="background-color: #2563eb; color: white; padding: 12px 24px; border-radius: 8px; text-decoration: none; font-weight: 600;">
+            Verify Email
+          </a>
+        </div>
+        <p style="color: #666; font-size: 14px;">Or copy and paste this link into your browser:</p>
+        <p style="color: #2563eb; font-size: 14px; word-break: break-all;">${verifyUrl}</p>
+        <p style="color: #666; font-size: 14px;">This link expires in 24 hours.</p>
+        <hr style="border: none; border-top: 1px solid #eee; margin: 30px 0;" />
+        <p style="color: #999; font-size: 12px;">If you didn't create an account, you can safely ignore this email.</p>
+      </div>
+    `,
+    text: `${greeting},\n\nVerify your ${APP_NAME} email: ${verifyUrl}\n\nThis link expires in 24 hours.\n\nIf you didn't create an account, ignore this email.`,
+  });
+}

--- a/src/lib/hooks/use-require-role.ts
+++ b/src/lib/hooks/use-require-role.ts
@@ -1,0 +1,28 @@
+"use client";
+
+import { useSession } from "next-auth/react";
+import { useRouter } from "next/navigation";
+import { useEffect } from "react";
+
+const PROVIDER_ROLES = ["PROVIDER", "ADMIN", "OWNER", "DOCTOR", "NURSE", "RECEPTIONIST"];
+
+/**
+ * Hook that redirects to /dashboard if the user doesn't have a provider role.
+ * Use as defense-in-depth on clinical pages (middleware already blocks, but this catches edge cases).
+ */
+export function useRequireProviderRole(): { allowed: boolean; loading: boolean } {
+  const { data: session, status } = useSession();
+  const router = useRouter();
+
+  const loading = status === "loading";
+  const role = session?.user?.role;
+  const allowed = !!role && PROVIDER_ROLES.includes(role);
+
+  useEffect(() => {
+    if (!loading && !allowed) {
+      router.replace("/dashboard");
+    }
+  }, [loading, allowed, router]);
+
+  return { allowed, loading };
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -64,6 +64,20 @@ if (typeof setInterval !== "undefined") {
   }, 60 * 1000);
 }
 
+// Routes only accessible to provider roles (not patients)
+const PROVIDER_ONLY_ROUTES = [
+  "/patients",
+  "/appointments",
+  "/lab-results",
+  "/eye-consultations",
+  "/equipment",
+  "/medical-history",
+  "/onboarding",
+  "/provider",
+];
+
+const PROVIDER_ROLES = new Set(["PROVIDER", "ADMIN", "OWNER", "DOCTOR", "NURSE", "RECEPTIONIST"]);
+
 export default withAuth(
   function middleware(req) {
     const token = req.nextauth.token;
@@ -75,8 +89,9 @@ export default withAuth(
       if (rateLimitResponse) return rateLimitResponse;
     }
 
-    // Provider-only routes
-    if (pathname.startsWith("/provider") && token?.role !== "PROVIDER" && token?.role !== "ADMIN") {
+    // Block PATIENT role from provider-only pages
+    const isProviderRoute = PROVIDER_ONLY_ROUTES.some((route) => pathname.startsWith(route));
+    if (isProviderRoute && token?.role && !PROVIDER_ROLES.has(token.role as string)) {
       return NextResponse.redirect(new URL("/dashboard", req.url));
     }
 
@@ -106,8 +121,18 @@ export const config = {
     "/records/:path*",
     "/care/:path*",
     "/family/:path*",
+    "/patients/:path*",
+    "/appointments/:path*",
+    "/lab-results/:path*",
+    "/eye-consultations/:path*",
+    "/equipment/:path*",
+    "/medical-history/:path*",
+    "/my-results/:path*",
+    "/onboarding/:path*",
     "/provider/:path*",
     "/admin/:path*",
+    "/profile/:path*",
+    "/settings/:path*",
     "/api/((?!auth|shared).*)/:path*",
   ],
 };


### PR DESCRIPTION
## Summary

Consolidates PRs #34 and #35 into a single clean PR with all 4 critical UX fixes for Option A.

### 1. Email Verification (Gmail SMTP)
- New fields on User model: `emailVerified`, `emailVerificationToken`, `emailVerificationExpiry`
- Registration generates a verification token and sends email via Gmail SMTP (nodemailer)
- `/api/auth/verify-email` validates tokens; `/api/auth/send-verification` resends with rate limiting
- `/verify-email` page with auto-verify, resend, and success/error states
- Login blocked until email is verified

### 2. Route Bypass Protection (Middleware + Client-side)
- Middleware expanded to block PATIENT role from all clinical pages (`/patients`, `/appointments`, `/lab-results`, `/equipment`, `/eye-consultations`, `/medical-history`)
- New `useRequireProviderRole` hook adds client-side role guard on all 6 clinical pages
- Patients redirected to `/dashboard` even if middleware is bypassed

### 3. Family Consent Flow (Two-way Accept/Reject)
- Token-based consent with 7-day expiry
- `sendFamilyConsentEmail()` sends email with Accept/Decline buttons
- `/api/family/consent` endpoint (GET for email links, POST for in-app)
- `/family/consent` page processes consent from email links
- In-app accept/reject buttons for pending requests
- Medical records blocked until consent is given
- Only the family member can control consent (not the adder)
- Schema: `consentToken`, `consentTokenExpiry`, `consentRespondedAt` on FamilyMember

### 4. Org Switcher (UI Component + JWT Refresh)
- New `OrgSwitcher` component in sidebar (desktop + mobile)
- Shows active org name + role with dropdown to switch between orgs
- `/api/auth/switch-org` PATCH + GET routes
- `preferred-org` cookie read in JWT callback to refresh `activeOrganizationId`

### Vercel Environment Variables Needed
| Name | Value |
|------|-------|
| `SMTP_HOST` | `smtp.gmail.com` |
| `SMTP_PORT` | `587` |
| `SMTP_USER` | `sopark.worker@gmail.com` |
| `SMTP_PASSWORD` | Gmail app password (myaccount.google.com > Security > App Passwords) |

## Files Changed (25)
- `prisma/schema.prisma` — consent + email verification fields
- `src/lib/email.ts` — nodemailer service (verification + consent emails)
- `src/lib/hooks/use-require-role.ts` — client-side role guard hook
- `src/lib/auth.ts` — JWT callback for org switching
- `src/lib/audit.ts` — EMAIL_VERIFIED + ORG_SWITCHED actions
- `src/middleware.ts` — PATIENT role blocking on clinical routes
- `src/app/api/auth/register/route.ts` — token generation on signup
- `src/app/api/auth/verify-email/route.ts` — token validation
- `src/app/api/auth/send-verification/route.ts` — resend with rate limit
- `src/app/api/auth/switch-org/route.ts` — org switching endpoint
- `src/app/api/family/consent/route.ts` — consent accept/reject API
- `src/app/api/family/route.ts` — consent token + email on family add
- `src/app/api/family/[id]/route.ts` — blocks records without consent
- `src/app/verify-email/page.tsx` — verification UI
- `src/app/(dashboard)/family/consent/page.tsx` — consent UI
- `src/app/(dashboard)/family/page.tsx` — pending requests UI
- `src/components/layout/Sidebar.tsx` — OrgSwitcher integration
- 6 clinical pages — `useRequireProviderRole` guard added

## Test Plan
- [x] 235 tests passing
- [x] Zero TypeScript errors
- [x] Production build clean
- [ ] Register new user -> redirected to verify-email page -> verify via email link -> can log in
- [ ] PATIENT login -> type `/patients` in URL -> redirected to `/dashboard`
- [ ] Add family member -> member receives email with Accept/Decline buttons
- [ ] Family member clicks Accept -> consent given, medical records visible
- [ ] Org switcher visible in sidebar -> switch org -> session updates

Closes #34, closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)